### PR TITLE
Gradually deliver presale tokens

### DIFF
--- a/contracts/CarryTokenCrowdsale.sol
+++ b/contracts/CarryTokenCrowdsale.sol
@@ -20,6 +20,11 @@ import "openzeppelin-solidity/contracts/crowdsale/validation/WhitelistedCrowdsal
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "./CarryToken.sol";
 
+/**
+ * @title CarryTokenCrowdsale
+ * @dev The common base contract for both sales: the Carry token presale,
+ * and the Carry token public crowdsale.
+ */
 contract CarryTokenCrowdsale is WhitelistedCrowdsale, CappedCrowdsale {
     using SafeMath for uint256;
 

--- a/contracts/CarryTokenPresale.sol
+++ b/contracts/CarryTokenPresale.sol
@@ -22,7 +22,7 @@ import "./GradualDeliveryCrowdsale.sol";
  * @title CarryTokenPresale
  * @dev The Carry token presale contract.
  */
-contract CarryTokenPresale is CarryTokenCrowdsale {
+contract CarryTokenPresale is CarryTokenCrowdsale, GradualDeliveryCrowdsale {
     // FIXME: Here we've wanted to use constructor() keyword instead,
     // but solium/solhint lint softwares don't parse it properly as of
     // April 2018.
@@ -40,6 +40,6 @@ contract CarryTokenPresale is CarryTokenCrowdsale {
         _cap,
         _individualMinPurchaseWei,
         _individualMaxCapWei
-    ) {
+    ) GradualDeliveryCrowdsale (_rate, _wallet, _token) {
     }
 }

--- a/contracts/CarryTokenPresale.sol
+++ b/contracts/CarryTokenPresale.sol
@@ -1,0 +1,45 @@
+// The Carry token and the tokensale contracts
+// Copyright (C) 2018 Carry Protocol
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+pragma solidity ^0.4.23;
+
+import "./CarryTokenCrowdsale.sol";
+import "./GradualDeliveryCrowdsale.sol";
+
+/**
+ * @title CarryTokenPresale
+ * @dev The Carry token presale contract.
+ */
+contract CarryTokenPresale is CarryTokenCrowdsale {
+    // FIXME: Here we've wanted to use constructor() keyword instead,
+    // but solium/solhint lint softwares don't parse it properly as of
+    // April 2018.
+    function CarryTokenPresale(
+        address _wallet,
+        CarryToken _token,
+        uint256 _rate,
+        uint256 _cap,
+        uint256 _individualMinPurchaseWei,
+        uint256 _individualMaxCapWei
+    ) public CarryTokenCrowdsale(
+        _wallet,
+        _token,
+        _rate,
+        _cap,
+        _individualMinPurchaseWei,
+        _individualMaxCapWei
+    ) {
+    }
+}

--- a/contracts/GradualDeliveryCrowdsale.sol
+++ b/contracts/GradualDeliveryCrowdsale.sol
@@ -1,0 +1,75 @@
+// The Carry token and the tokensale contracts
+// Copyright (C) 2018 Carry Protocol
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+pragma solidity ^0.4.23;
+
+import "openzeppelin-solidity/contracts/crowdsale/Crowdsale.sol";
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+
+/**
+ * @title GradualDeliveryCrowdsale
+ * @dev Crowdsale that does not deliver tokens to a beneficiary immediately
+ * after they has just purchased, but instead partially delivers tokens through
+ * several times when the contract owner calls deliverTokenRatio() method.
+ */
+contract GradualDeliveryCrowdsale is Crowdsale, Ownable {
+    using SafeMath for uint256;
+
+    mapping(address => uint256) public balances;
+    address[] beneficiaries;
+
+    // FIXME: Here we've wanted to use constructor() keyword instead,
+    // but solium/solhint lint softwares don't parse it properly as of
+    // April 2018.
+    function GradualDeliveryCrowdsale(
+        uint256 _rate,
+        address _wallet,
+        ERC20 _token
+    ) public Crowdsale(_rate, _wallet, _token) Ownable() {
+    }
+
+    /**
+     * @dev Deliver only the given ratio of tokens to the beneficiaries.
+     * For example, where there are two beneficiaries of each balance 90 CRE and
+     * 60 CRE, deliverTokensInRatio(1, 3) delivers each 30 CRE and 20 CRE to
+     * them.  In the similar way, deliverTokensInRatio(1, 1) delivers
+     * their entire tokens.
+     */
+    function deliverTokensInRatio(
+        uint256 _numerator,
+        uint256 _denominator
+    ) external onlyOwner {
+        require(_numerator <= _denominator);
+        for (uint i = 0; i < beneficiaries.length; i = i.add(1)) {
+            address beneficiary = beneficiaries[i];
+            uint256 balance = balances[beneficiary];
+            if (balance > 0) {
+                uint256 amount = balance.mul(_numerator).div(_denominator);
+                balances[beneficiary] = balance.sub(amount);
+                _deliverTokens(beneficiary, amount);
+            }
+        }
+    }
+
+    function _processPurchase(
+        address _beneficiary,
+        uint256 _tokenAmount
+    ) internal {
+        beneficiaries.push(_beneficiary);
+        balances[_beneficiary] = balances[_beneficiary].add(_tokenAmount);
+    }
+}

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 const CarryToken = artifacts.require("CarryToken");
-const CarryTokenCrowdsale = artifacts.require("CarryTokenCrowdsale");
+const CarryTokenPresale = artifacts.require("CarryTokenPresale");
 
 const presale = {
     // See also <https://carryprotocol.io/#section-token-distribution>.
@@ -43,7 +43,7 @@ module.exports = (deployer, network, accounts) => {
     }).then((_carryToken) => {
         carryToken = _carryToken;
         return deployer.deploy(
-            CarryTokenCrowdsale,
+            CarryTokenPresale,
             accounts[0],
             carryToken.address,
             presale.rate,
@@ -52,10 +52,10 @@ module.exports = (deployer, network, accounts) => {
             presale.individualMaxCapWei
         );
     }).then(() => {
-        return CarryTokenCrowdsale.deployed();
-    }).then((carryTokenCrowdsale) => {
+        return CarryTokenPresale.deployed();
+    }).then((carryTokenPresale) => {
         return carryToken.mint(
-            carryTokenCrowdsale.address,
+            carryTokenPresale.address,
             new web3.BigNumber(presale.cap).mul(presale.rate),
             {from: accounts[0]}
         );

--- a/test/carryTokenCrowdsale.js
+++ b/test/carryTokenCrowdsale.js
@@ -16,7 +16,30 @@
 const { assertEq, assertFail, multipleContracts } = require("./utils");
 
 multipleContracts(
-    ["CarryTokenCrowdsale", "CarryTokenPresale"],
+    {
+        "CarryTokenCrowdsale": (fundWallet, token) => [
+            // Use the same arguments to the presale (though not necessarily).
+            // See also presale constant on migrations/2_deploy_contracts.js
+            // file.
+            fundWallet,  // wallet
+            token.address,  // token contract
+            74750,  // rate
+            web3.toWei(5000410, "finney"),  // cap
+            web3.toWei(99, "finney"),  // individualMinPurchaseWei
+            web3.toWei(50, "ether"),  // individualMaxCapWei
+        ],
+        "CarryTokenPresale": (fundWallet, token) => [
+            // Use the same arguments to the presale (though not necessarily).
+            // See also presale constant on migrations/2_deploy_contracts.js
+            // file.
+            fundWallet,  // wallet
+            token.address,  // token contract
+            74750,  // rate
+            web3.toWei(5000410, "finney"),  // cap
+            web3.toWei(99, "finney"),  // individualMinPurchaseWei
+            web3.toWei(50, "ether"),  // individualMaxCapWei
+        ],
+    },
     async function ({ getAccount, fundWallet, fundOwner, getFund }) {
         function withoutBalanceChangeIt (label, fA, fB) {
             it(label, async () => {

--- a/test/gradualDeliveryCrowdsale.js
+++ b/test/gradualDeliveryCrowdsale.js
@@ -1,0 +1,136 @@
+// The Carry token and the tokensale contracts
+// Copyright (C) 2018 Carry Protocol
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+const {
+    assertEq,
+    assertFail,
+    assertNotEq,
+    multipleContracts,
+} = require("./utils");
+
+multipleContracts(
+    {
+        "GradualDeliveryCrowdsale": (fundWallet, token) => [
+            74750,  // rate
+            fundWallet,  // wallet
+            token.address,  // token contract
+        ],
+        "CarryTokenPresale": (fundWallet, token) => [
+            // Use the same arguments to the presale (though not necessarily).
+            // See also presale constant on migrations/2_deploy_contracts.js
+            // file.
+            fundWallet,  // wallet
+            token.address,  // token contract
+            74750,  // rate
+            web3.toWei(5000410, "finney"),  // cap
+            web3.toWei(99, "finney"),  // individualMinPurchaseWei
+            web3.toWei(50, "ether"),  // individualMaxCapWei
+        ],
+    },
+    async ({ contractName, getAccount, fundOwner, getFund, getToken }) => {
+        async function addToWhitelist(...contributors) {
+            if (contractName === "CarryTokenPresale") {
+                const fund = getFund();
+                await fund.addManyToWhitelist(
+                    contributors,
+                    {from: fundOwner}
+                );
+            }
+        }
+
+        it(
+            "should not withdraw tokens immediately after purchase",
+            async function () {
+                const contributor = getAccount();
+                const fund = getFund();
+                const token = getToken();
+                const prevBalance = await token.balanceOf(contributor);
+                await addToWhitelist(contributor);
+                await fund.sendTransaction({
+                    value: web3.toWei(100, "finney"),
+                    from: contributor,
+                });
+                const nextBalance = await token.balanceOf(contributor);
+                assertEq(
+                    prevBalance,
+                    nextBalance,
+                    "Token must not be withdrawn imediately after purchase"
+                );
+            }
+        );
+
+        it("disallows withdrawal by other than the owner", async function () {
+            const nonOwner = getAccount();
+            const fund = getFund();
+            await assertFail(
+                fund.deliverTokensInRatio(1, 2, { from: nonOwner }),
+                "Withdrawal should be failed due to the lack of permission"
+            );
+        });
+
+        it("delivers tokens in the specified ratio", async function () {
+            const contributors = [getAccount(), getAccount(), getAccount()];
+            const fund = getFund();
+            const token = getToken();
+            const initialBalances =
+                await Promise.all(contributors.map(c => token.balanceOf(c)));
+            await addToWhitelist(...contributors);
+            const etherAmounts = [
+                web3.toWei(100, "finney"),
+                web3.toWei(500, "finney"),
+                0,
+            ];
+            assert.equal(etherAmounts.length, contributors.length);
+            for (let i = 0; i < etherAmounts.length; i++) {
+                if (etherAmounts[i] < 1) {
+                    continue;
+                }
+                await fund.sendTransaction({
+                    value: etherAmounts[i],
+                    from: contributors[i],
+                });
+            }
+            const intermediateBalances =
+                await Promise.all(contributors.map(c => token.balanceOf(c)));
+            for (let i = 0; i < initialBalances.length; i++) {
+                assertEq(
+                    initialBalances[i], intermediateBalances[i],
+                    "Token must not be withdrawn imediately after purchase"
+                );
+            }
+            await fund.deliverTokensInRatio(1, 2, {from: fundOwner});
+            const finalBalances =
+                await Promise.all(contributors.map(c => token.balanceOf(c)));
+            assertNotEq(
+                initialBalances[0],
+                finalBalances[0],
+                "No token was transferred"
+            );
+            assertNotEq(
+                initialBalances[1],
+                finalBalances[1],
+                "No token was transferred"
+            );
+            const rate = await fund.rate();
+            for (let i = 0; i < initialBalances.length; i++) {
+                assertEq(
+                    finalBalances[i].minus(initialBalances[i]),
+                    rate.mul(etherAmounts[i]).div(2),
+                    "Only half of tokens should be transferred"
+                );
+            }
+        });
+    }
+);

--- a/test/utils.js
+++ b/test/utils.js
@@ -58,11 +58,26 @@ function multipleContracts(contracts, callback) {
 }
 
 function assertEq(expected, actual, message) {
+    expected = new web3.BigNumber(expected);
     assert.isTrue(
         expected.eq(actual),
-        message + "\n      expected: " + expected.toString() +
+        message +
+        "\n      expected: " + expected.toString() +
         "\n      actual:   " + actual.toString() +
-        "\n      delta:    " + expected.minus(actual).toString() + "\n      "
+        "\n      delta:    " + expected.minus(actual).toString() +
+        "\n      "
+    );
+}
+
+function assertNotEq(expected, actual, message) {
+    expected = new web3.BigNumber(expected);
+    assert.isFalse(
+        expected.eq(actual),
+        message +
+        "\nexpected not to be: " + expected.toString() +
+        "\n      actual:       " + actual.toString() +
+        "\n      delta:        " + expected.minus(actual).toString() +
+        "\n      "
     );
 }
 
@@ -78,7 +93,8 @@ async function assertFail(promise, message) {
 }
 
 module.exports = {
-    multipleContracts: multipleContracts,
-    assertEq: assertEq,
-    assertFail: assertFail,
+    multipleContracts,
+    assertEq,
+    assertNotEq,
+    assertFail,
 };

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,5 +1,62 @@
 /* eslint-disable no-console */
 
+function multipleContracts(contracts, callback) {
+    for (const contractName of contracts) {
+        const CarryToken = artifacts.require("CarryToken");
+        const Contract = artifacts.require(contractName);
+
+        contract(contractName, async function (accounts) {
+            const reservedAccounts = 1;
+            let accountIndex = reservedAccounts;
+            const getAccount = () => {
+                const account = accounts[accountIndex++];
+                if (accountIndex >= accounts.length) {
+                    accountIndex = reservedAccounts;
+                }
+                return account;
+            };
+
+            const fundWallet = accounts[0];
+            const fundOwner = accounts[0];
+            let fund;
+
+            before(async function () {
+                try {
+                    fund = await Contract.deployed();
+                } catch (e) {
+                    let carryToken = await CarryToken.deployed();
+                    fund = await Contract.new(
+                        // Use the same arguments to the presale.  See also
+                        // presale constant on migrations/2_deploy_contracts.js
+                        // file.
+                        fundWallet,  // wallet
+                        carryToken.address,  // token
+                        74750,  // rate
+                        web3.toWei(5000410, "finney"),  // cap
+                        web3.toWei(99, "finney"),  // individualMinPurchaseWei
+                        web3.toWei(50, "ether"),  // individualMaxCapWei
+                    );
+                    await carryToken.mint(
+                        fund.address,
+                        new web3.BigNumber(
+                            web3.toWei(5000410, "finney")
+                        ).mul(74750),
+                        {from: fundOwner}
+                    );
+                }
+            });
+
+            callback({
+                accounts,
+                getAccount,
+                fundWallet,
+                fundOwner,
+                getFund: () => fund,
+            });
+        });
+    }
+}
+
 function assertEq(expected, actual, message) {
     assert.isTrue(
         expected.eq(actual),
@@ -21,6 +78,7 @@ async function assertFail(promise, message) {
 }
 
 module.exports = {
+    multipleContracts: multipleContracts,
     assertEq: assertEq,
     assertFail: assertFail,
 };


### PR DESCRIPTION
As we're going to prevent to deliver the whole tokens to presale purchasers at a time, but instead gradually deliver them partial tokens through several times, this patch made the following changes:

- Since policies between token presale and public crowdsale became to differ in many ways, `CarryTokenPresale` contract from `CarryTokenCrowdsale` contract.  The existing `CarryTokenCrowdsale` remains as a common base contract for both token sales.
- `GradualDeliveryCrowdsale` is a base contract that prevents immediate token delivery to a token purchaser and implements delayed partial (in the specified ratio) delivery of tokens.  Now `CarryTokenPresale` inherits it.
- In order to run the same test for a base contract and a concrete contract inheriting it both, extract common codes about fixture & etc. from the existing test for `CarryTokenCrowdsale` and named it `multipleContracts`.