### PR TITLE
Deliver tokens from and to a specific offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,20 @@ capped token.
 This repository contains:
 
 - `CarryToken` contract which declares the **CRE** token based on
-  [OpenZeppelin]'s [`CappedToken`][CappedToken] contract, and
+  [OpenZeppelin]'s [`CappedToken`][CappedToken] contract,
 
-- `CarryTokenCrowdsale` which declares the token crowdsale contract,
-  which is based on [OpenZeppelin]'s [`CappedCrowdsale`][CappedCrowdsale] &
-  [WhitelistedCrowdsale][] contracts, to be used for the Carry token presale &
-  public sale.
+- `CarryTokenCrowdsale` which declares the common base contract for token
+  crowdsale and is based on [OpenZeppelin]'s [`CappedCrowdsale`][CappedCrowdsale]
+  & [WhitelistedCrowdsale][] contracts, to be used for the Carry token presale &
+  public sale,
+
+- `GradualDeliveryCrowdsale` which declares the base contract for token
+  crowdsale that does not deliver tokens to a beneficiary immediately after
+  they has just purchased, but instead partially delivers tokens through
+  several times, and
+
+- `CarryTokenPresale` which declares the contract for the Carry token presale
+  and inherits above `CarryTokenCrowdsale` and `GradualDeliveryCrowdsale`.
 
 [ci-image]: https://travis-ci.org/carryprotocol/carry-token-crowdsale.svg?branch=master
 [ci]: https://travis-ci.org/carryprotocol/carry-token-crowdsale

--- a/contracts/GradualDeliveryCrowdsale.sol
+++ b/contracts/GradualDeliveryCrowdsale.sol
@@ -32,16 +32,6 @@ contract GradualDeliveryCrowdsale is Crowdsale, Ownable {
     mapping(address => uint256) public balances;
     address[] beneficiaries;
 
-    // FIXME: Here we've wanted to use constructor() keyword instead,
-    // but solium/solhint lint softwares don't parse it properly as of
-    // April 2018.
-    function GradualDeliveryCrowdsale(
-        uint256 _rate,
-        address _wallet,
-        ERC20 _token
-    ) public Crowdsale(_rate, _wallet, _token) Ownable() {
-    }
-
     /**
      * @dev Deliver only the given ratio of tokens to the beneficiaries.
      * For example, where there are two beneficiaries of each balance 90 CRE and

--- a/contracts/GradualDeliveryCrowdsale.sol
+++ b/contracts/GradualDeliveryCrowdsale.sol
@@ -27,6 +27,7 @@ import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
  * several times when the contract owner calls deliverTokenRatio() method.
  */
 contract GradualDeliveryCrowdsale is Crowdsale, Ownable {
+    using SafeMath for uint;
     using SafeMath for uint256;
 
     mapping(address => uint256) public balances;
@@ -43,8 +44,41 @@ contract GradualDeliveryCrowdsale is Crowdsale, Ownable {
         uint256 _numerator,
         uint256 _denominator
     ) external onlyOwner {
+        _deliverTokensInRatio(
+            _numerator,
+            _denominator,
+            0,
+            beneficiaries.length
+        );
+    }
+
+    /**
+     * @dev It's mostly same to deliverTokensInRatio(), except it processes
+     * only a particular range of the list of beneficiaries.
+     */
+    function deliverTokensInRatioFromTo(
+        uint256 _numerator,
+        uint256 _denominator,
+        uint _from,
+        uint _to
+    ) external onlyOwner {
+        require(_from < _to);
+        _deliverTokensInRatio(_numerator, _denominator, _from, _to);
+    }
+
+    function _deliverTokensInRatio(
+        uint256 _numerator,
+        uint256 _denominator,
+        uint _from,
+        uint _to
+    ) internal {
+        require(_denominator > 0);
         require(_numerator <= _denominator);
-        for (uint i = 0; i < beneficiaries.length; i = i.add(1)) {
+        uint to = _to;
+        if (to > beneficiaries.length) {
+            to = beneficiaries.length;
+        }
+        for (uint i = _from; i < to; i = i.add(1)) {
             address beneficiary = beneficiaries[i];
             uint256 balance = balances[beneficiary];
             if (balance > 0) {

--- a/test/SampleGradualDeliveryCrowdsale.sol
+++ b/test/SampleGradualDeliveryCrowdsale.sol
@@ -15,31 +15,21 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 pragma solidity ^0.4.23;
 
-import "./CarryTokenCrowdsale.sol";
-import "./GradualDeliveryCrowdsale.sol";
+import "openzeppelin-solidity/contracts/crowdsale/Crowdsale.sol";
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import "../contracts/GradualDeliveryCrowdsale.sol";
 
-/**
- * @title CarryTokenPresale
- * @dev The Carry token presale contract.
- */
-contract CarryTokenPresale is CarryTokenCrowdsale, GradualDeliveryCrowdsale {
+// Since GradualDeliveryCrowdsale is abstract and does not have its own
+// constructor, we need to define a concrete class inheriting it and having
+// its own constructor.
+contract SampleGradualDeliveryCrowdsale is GradualDeliveryCrowdsale {
     // FIXME: Here we've wanted to use constructor() keyword instead,
     // but solium/solhint lint softwares don't parse it properly as of
     // April 2018.
-    function CarryTokenPresale(
-        address _wallet,
-        CarryToken _token,
+    function SampleGradualDeliveryCrowdsale(
         uint256 _rate,
-        uint256 _cap,
-        uint256 _individualMinPurchaseWei,
-        uint256 _individualMaxCapWei
-    ) public CarryTokenCrowdsale(
-        _wallet,
-        _token,
-        _rate,
-        _cap,
-        _individualMinPurchaseWei,
-        _individualMaxCapWei
-    ) {
+        address _wallet,
+        ERC20 _token
+    ) public Crowdsale(_rate, _wallet, _token) Ownable() {
     }
 }

--- a/test/gradualDeliveryCrowdsale.js
+++ b/test/gradualDeliveryCrowdsale.js
@@ -22,7 +22,7 @@ const {
 
 multipleContracts(
     {
-        "GradualDeliveryCrowdsale": (fundWallet, token) => [
+        "SampleGradualDeliveryCrowdsale": (fundWallet, token) => [
             74750,  // rate
             fundWallet,  // wallet
             token.address,  // token contract

--- a/test/gradualDeliveryCrowdsale.js
+++ b/test/gradualDeliveryCrowdsale.js
@@ -39,7 +39,9 @@ multipleContracts(
             web3.toWei(50, "ether"),  // individualMaxCapWei
         ],
     },
-    async ({ contractName, getAccount, fundOwner, getFund, getToken }) => {
+    async ({
+        contractName, getAccount, fundOwner, getFund, getToken, createFund,
+    }) => {
         async function addToWhitelist(...contributors) {
             if (contractName === "CarryTokenPresale") {
                 const fund = getFund();
@@ -130,6 +132,49 @@ multipleContracts(
                     rate.mul(etherAmounts[i]).div(2),
                     "Only half of tokens should be transferred"
                 );
+            }
+        });
+
+        it("can deliver tokens from & to a particular offset", async () => {
+            const contributors = [
+                getAccount(), getAccount(), getAccount(),
+                getAccount(), getAccount(), getAccount(),
+            ];
+            const fund = await createFund();
+            // Since Truffle doesn't provide true clean-room fixture but
+            // it is stateful, we need to create a new token sale contract.
+            const token = getToken();
+            const initialBalances =
+                await Promise.all(contributors.map(c => token.balanceOf(c)));
+            await addToWhitelist(...contributors);
+            for (let i = 0; i < contributors.length; i++) {
+                await fund.sendTransaction({
+                    value: web3.toWei((i + 1) * 100, "finney"),
+                    from: contributors[i],
+                });
+            }
+            const from = 2, to = 5;
+            await fund.deliverTokensInRatioFromTo(
+                1, 2, from, to,
+                {from: fundOwner}
+            );
+            const finalBalances =
+                await Promise.all(contributors.map(c => token.balanceOf(c)));
+            const rate = await fund.rate();
+            for (let i = 0; i < contributors.length; i++) {
+                if (from <= i && i < to) {
+                    assertEq(
+                        rate.mul(web3.toWei(50, "finney")).mul(i + 1),
+                        finalBalances[i].minus(initialBalances[i]),
+                        "Half of tokens should be transferred [" + i + "]"
+                    );
+                } else {
+                    assertEq(
+                        finalBalances[i],
+                        initialBalances[i],
+                        "No tokens should be transferred [" + i + "]"
+                    );
+                }
             }
         });
     }

--- a/test/utils.js
+++ b/test/utils.js
@@ -21,19 +21,27 @@ function multipleContracts(contracts, callback) {
             let fund = null;
             let token = null;
 
+            const createFund = async (returnToken = false) => {
+                token = await CarryToken.deployed();
+                fund = await Contract.new(...initArgs(fundWallet, token));
+                await token.mint(
+                    fund.address,
+                    new web3.BigNumber(
+                        web3.toWei(5000410, "finney")
+                    ).mul(74750),
+                    {from: fundOwner}
+                );
+                if (returnToken) {
+                    return [fund, token];
+                }
+                return fund;
+            };
+
             before(async function () {
                 try {
                     fund = await Contract.deployed();
                 } catch (e) {
-                    token = await CarryToken.deployed();
-                    fund = await Contract.new(...initArgs(fundWallet, token));
-                    await token.mint(
-                        fund.address,
-                        new web3.BigNumber(
-                            web3.toWei(5000410, "finney")
-                        ).mul(74750),
-                        {from: fundOwner}
-                    );
+                    [fund, token] = await createFund(true);
                 }
                 if (token == null) {
                     token = new CarryToken(await fund.token());
@@ -48,6 +56,7 @@ function multipleContracts(contracts, callback) {
                 fundOwner,
                 getFund: () => fund,
                 getToken: () => token,
+                createFund: createFund,
             });
         });
     }


### PR DESCRIPTION
The total amount of EVM operations to be run by `GradualDeliveryCrowdsale.deliverTokensInRatio()` could be up to the length of its `beneficiaries`.  The more contributors purchased, the more EVM operations is run, hence the more gas fee.

Since there's the maximum amount of gas for a function call on the Ethereum network, with a certain contributors who purchase our tokens, a call to `deliverTokensInRatio()` function could exhaust the maximum gas.  As a failed transaction rolls back every change made during the call, we might totally be unable to deliver any tokens to contributors.

In order to work around such corner cases, this patch adds an alternative function `deliverTokenInRatioFromTo()`.  It's almost same to `deliverTokensInRatio()` except it takes two more arguments to start from and stop at in a loop.