### PR TITLE
Refund features

### DIFF
--- a/contracts/GradualDeliveryCrowdsale.sol
+++ b/contracts/GradualDeliveryCrowdsale.sol
@@ -25,6 +25,7 @@ import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
  * @dev Crowdsale that does not deliver tokens to a beneficiary immediately
  * after they has just purchased, but instead partially delivers tokens through
  * several times when the contract owner calls deliverTokenRatio() method.
+ * Note that it also provides methods to selectively refund some purchases.
  */
 contract GradualDeliveryCrowdsale is Crowdsale, Ownable {
     using SafeMath for uint;
@@ -32,6 +33,7 @@ contract GradualDeliveryCrowdsale is Crowdsale, Ownable {
 
     mapping(address => uint256) public balances;
     address[] beneficiaries;
+    mapping(address => uint256) public refundedDeposits;
 
     /**
      * @dev Deliver only the given ratio of tokens to the beneficiaries.
@@ -95,5 +97,60 @@ contract GradualDeliveryCrowdsale is Crowdsale, Ownable {
     ) internal {
         beneficiaries.push(_beneficiary);
         balances[_beneficiary] = balances[_beneficiary].add(_tokenAmount);
+    }
+    /**
+     * @dev Refund the given ether to a beneficiary.  It only can be called by
+     * either the contract owner or the wallet (i.e. Crowdsale.wallet) address.
+     * The only amount of the ether sent together in a transaction is refunded.
+     */
+    function depositRefund(address _beneficiary) public payable {
+        require(msg.sender == owner || msg.sender == wallet);
+        uint256 weiToRefund = msg.value;
+        require(weiToRefund <= weiRaised);
+        uint256 tokensToRefund = _getTokenAmount(weiToRefund);
+        uint256 tokenBalance = balances[_beneficiary];
+        require(tokenBalance >= tokensToRefund);
+        weiRaised = weiRaised.sub(weiToRefund);
+        balances[_beneficiary] = tokenBalance.sub(tokensToRefund);
+        refundedDeposits[_beneficiary] = weiToRefund;
+    }
+
+    /**
+     * @dev Receive one's refunded ethers in the deposit.  It can be called by
+     * either the contract owner or the beneficiary of the refund.
+     * The deposited ether is sent to only the beneficiary regardless it is
+     * called by which address, either the contract owner or the beneficary.
+     * It usually can be systemically called together right after
+     * depositRefund() is called.
+     */
+    function receiveRefund(address _beneficiary) public {
+        require(msg.sender == owner || msg.sender == _beneficiary);
+        _transferRefund(_beneficiary, _beneficiary);
+    }
+
+    /**
+     * @dev Similar to receiverRefund() except that it cannot be called by
+     * even the contract owner, but only the beneficiary of the refund.
+     * It also takes an additional parameter, a wallet address to receiver
+     * the deposited (refunded) ethers.
+     * The main purpose of this method is to receive the refunded ethers
+     * to the other address than the beneficiary address.  Usually after
+     * depositRefund() is called, receiveRefund() is immediately executed
+     * together by the automated system, but there could be cases that
+     * the the beneficiary address is a smart contract and it causes
+     * the transaction to transfer ethers in any reason.  In such cases,
+     * the deposit beneficiary need to "pull" his ethers to his another
+     * wallet address by calling this method.
+     */
+    function receiveRefundTo(address _beneficiary, address _wallet) public {
+        require(msg.sender == _beneficiary);
+        _transferRefund(_beneficiary, _wallet);
+    }
+
+    function _transferRefund(address _beneficiary, address _wallet) internal {
+        uint256 depositedWeiAmount = refundedDeposits[_beneficiary];
+        require(depositedWeiAmount > 0);
+        refundedDeposits[_beneficiary] = 0;
+        _wallet.transfer(depositedWeiAmount);
     }
 }

--- a/contracts/GradualDeliveryCrowdsale.sol
+++ b/contracts/GradualDeliveryCrowdsale.sol
@@ -112,7 +112,9 @@ contract GradualDeliveryCrowdsale is Crowdsale, Ownable {
         require(tokenBalance >= tokensToRefund);
         weiRaised = weiRaised.sub(weiToRefund);
         balances[_beneficiary] = tokenBalance.sub(tokensToRefund);
-        refundedDeposits[_beneficiary] = weiToRefund;
+        refundedDeposits[_beneficiary] = refundedDeposits[_beneficiary].add(
+            weiToRefund
+        );
     }
 
     /**

--- a/test/gradualDeliveryCrowdsale.js
+++ b/test/gradualDeliveryCrowdsale.js
@@ -431,6 +431,32 @@ multipleContracts(
             }
         );
 
+        it("accumulate the deposit if refunded multiple times", async () => {
+            const {
+                fund,
+                beneficiary,
+            } = await setUpRefundDepositedState(
+                web3.toWei(500, "finney"),
+                web3.toWei(100, "finney"),
+            );
+            let deposit = await fund.refundedDeposits(beneficiary);
+            assertEq(
+                web3.toWei(100, "finney"),
+                deposit,
+                "The remain deposit should be 0.1 ETH"
+            );
+            await fund.depositRefund(beneficiary, {
+                value: web3.toWei(100, "finney"),
+                from: fundOwner,
+            });
+            deposit = await fund.refundedDeposits(beneficiary);
+            assertEq(
+                web3.toWei(200, "finney"),
+                deposit,
+                "The remain deposit should be 0.2 ETH"
+            );
+        });
+
         it(
             "disallows any other than the beneficiary to receive the " +
             "refunded deposit to a specified address",

--- a/test/gradualDeliveryCrowdsale.js
+++ b/test/gradualDeliveryCrowdsale.js
@@ -40,7 +40,13 @@ multipleContracts(
         ],
     },
     async ({
-        contractName, getAccount, fundOwner, getFund, getToken, createFund,
+        contractName,
+        getAccount,
+        fundOwner,
+        fundWallet,
+        getFund,
+        getToken,
+        createFund,
     }) => {
         async function addToWhitelist(...contributors) {
             if (contractName === "CarryTokenPresale") {
@@ -177,5 +183,276 @@ multipleContracts(
                 }
             }
         });
+
+        // fixture
+        async function setUpPurchasedState(value) {
+            const fund = await createFund();
+            const beneficiary = getAccount();
+            await addToWhitelist(beneficiary);
+            await fund.sendTransaction({
+                value,
+                from: beneficiary,
+            });
+            return {
+                fund,
+                beneficiary,
+            };
+        }
+
+        it(
+            "disallows to be requested to refund by other than the fund " +
+            "owner or the fund wallet",
+            async function () {
+                const {
+                    fund,
+                    beneficiary,
+                } = await setUpPurchasedState(web3.toWei(500, "finney"));
+                const previousWeiRaised = await fund.weiRaised();
+                await assertFail(
+                    fund.depositRefund(beneficiary, {
+                        value: web3.toWei(500, "finney"),
+                        from: beneficiary,
+                    }),
+                    "Refund should be failed due to the lack of permission"
+                );
+                assertEq(
+                    previousWeiRaised,
+                    await fund.weiRaised(),
+                    "The refund should not affect to weiRaised amount."
+                );
+                const thirdPerson = getAccount();
+                await assertFail(
+                    fund.depositRefund(beneficiary, {
+                        value: web3.toWei(500, "finney"),
+                        from: thirdPerson,
+                    }),
+                    "Refund should be failed due to the lack of permission"
+                );
+                assertEq(
+                    previousWeiRaised,
+                    await fund.weiRaised(),
+                    "The refund should not affect to weiRaised amount."
+                );
+            }
+        );
+
+        for (const [label, executor] of Object.entries({
+            owner: fundOwner,
+            wallet: fundWallet,
+        })) {
+            it(
+                "allows the fund " + label + " to request to refund a purchase",
+                async function () {
+                    const {
+                        fund,
+                        beneficiary,
+                    } = await setUpPurchasedState(web3.toWei(500, "finney"));
+                    const previousWeiRaised = await fund.weiRaised();
+                    await fund.depositRefund(beneficiary, {
+                        value: web3.toWei(300, "finney"),
+                        from: executor,
+                    });
+                    const rate = await fund.rate();
+                    assertEq(
+                        rate.mul(web3.toWei(200, "finney")),
+                        await fund.balances(beneficiary),
+                        "A beneficiary's balance has to be consumed."
+                    );
+                    assertEq(
+                        web3.toWei(300, "finney"),
+                        await fund.refundedDeposits(beneficiary),
+                        "A beneficiary's refunded deposit has to be filled."
+                    );
+                    assertEq(
+                        previousWeiRaised.minus(web3.toWei(300, "finney")),
+                        await fund.weiRaised(),
+                        "The refund should affect to weiRaised amount."
+                    );
+                }
+            );
+
+            it("disallows to refund more than purchased", async function () {
+                const {
+                    fund,
+                    beneficiary,
+                } = await setUpPurchasedState(web3.toWei(500, "finney"));
+                await assertFail(
+                    fund.depositRefund(beneficiary, {
+                        value: web3.toWei(501, "finney"),
+                        from: executor,
+                    }),
+                    "Refund should be failed due to the insufficient balance."
+                );
+                const rate = await fund.rate();
+                assertEq(
+                    rate.mul(web3.toWei(500, "finney")),
+                    await fund.balances(beneficiary),
+                    "The balance should not change"
+                );
+            });
+        }
+
+        it(
+            "disallows to receive the refund if there is no refunded deposit",
+            async function () {
+                const {
+                    fund,
+                    beneficiary,
+                } = await setUpPurchasedState(web3.toWei(500, "finney"));
+                await assertFail(
+                    fund.receiveRefund(beneficiary, {
+                        from: beneficiary
+                    }),
+                    "Withdrawal should be failed due to the lack of deposit"
+                );
+            }
+        );
+
+        // fixture
+        async function setUpRefundDepositedState(purchased, refunded) {
+            purchased = new web3.BigNumber(purchased);
+            assert.isTrue(
+                purchased.gte(refunded),
+                "The purchased amount (" + purchased.toString() + ") has to " +
+                "equal to or be greater than the amount to refund (" +
+                refunded.toString() + ")"
+            );
+            const {
+                fund,
+                beneficiary,
+            } = await setUpPurchasedState(purchased);
+            await fund.depositRefund(beneficiary, {
+                value: refunded,
+                from: fundWallet,
+            });
+            return {
+                fund,
+                beneficiary,
+            };
+        }
+
+        it(
+            "disallows to receive the refund by other than the fund owner " +
+            "or the beneficiary",
+            async function () {
+                const {
+                    fund,
+                    beneficiary,
+                } = await setUpRefundDepositedState(
+                    web3.toWei(500, "finney"),
+                    web3.toWei(500, "finney"),
+                );
+                const thirdPerson = getAccount();
+                await assertFail(
+                    fund.receiveRefund(beneficiary, { from: thirdPerson }),
+                    "Withdrawal from the refunded deposit should be failed."
+                );
+            }
+        );
+
+        for (const [label, getExecutor] of Object.entries({
+            "fund owner": () => fundOwner,
+            beneficiary: (address) => address,
+        })) {
+            it(
+                "allows the " + label + " to receive the refunded deposit",
+                async function () {
+                    const {
+                        fund,
+                        beneficiary,
+                    } = await setUpRefundDepositedState(
+                        web3.toWei(500, "finney"),
+                        web3.toWei(500, "finney"),
+                    );
+                    const previousEther = web3.eth.getBalance(beneficiary);
+                    const executor = getExecutor(beneficiary);
+                    await fund.receiveRefund(beneficiary, { from: executor });
+                    assertEq(
+                        0,
+                        await fund.refundedDeposits(beneficiary),
+                        "The refunded deposit should be empty."
+                    );
+                    if (executor == beneficiary) {
+                        /* If an executor is the same to the beneficiary,
+                        we need to calculate the gas fee used for making
+                        a transaction. */
+                        const currentEther = web3.eth.getBalance(beneficiary);
+                        assert.isTrue(
+                            currentEther.gt(
+                                previousEther.plus(web3.toWei(490, "finney"))
+                            ),
+                            "The balance should be greater than 0.49 ETH: " +
+                            currentEther.minus(previousEther).toString()
+                        );
+                        assert.isTrue(
+                            currentEther.lte(
+                                previousEther.plus(web3.toWei(500, "finney"))
+                            ),
+                            "The balance should be less than 0.501 ETH: " +
+                            currentEther.minus(previousEther).toString()
+                        );
+                    } else {
+                        assertEq(
+                            previousEther.plus(web3.toWei(500, "finney")),
+                            web3.eth.getBalance(beneficiary),
+                            "The purchased ethers should be completely refunded"
+                        );
+                    }
+                }
+            );
+        }
+
+        it(
+            "allows the beneficiary to receive the refunded deposit to " +
+            "his another account (address)",
+            async function () {
+                const {
+                    fund,
+                    beneficiary,
+                } = await setUpRefundDepositedState(
+                    web3.toWei(500, "finney"),
+                    web3.toWei(500, "finney"),
+                );
+                const anotherAddress = getAccount();
+                const previousEther = web3.eth.getBalance(anotherAddress);
+                await fund.receiveRefundTo(beneficiary, anotherAddress, {
+                    from: beneficiary,
+                });
+                assertEq(
+                    0,
+                    await fund.refundedDeposits(beneficiary),
+                    "The refunded deposit should be empty."
+                );
+                assertEq(
+                    previousEther.plus(web3.toWei(500, "finney")),
+                    web3.eth.getBalance(anotherAddress),
+                    "The purchased ethers should be completely refunded."
+                );
+            }
+        );
+
+        it(
+            "disallows any other than the beneficiary to receive the " +
+            "refunded deposit to a specified address",
+            async function () {
+                const {
+                    fund,
+                    beneficiary,
+                } = await setUpRefundDepositedState(
+                    web3.toWei(500, "finney"),
+                    web3.toWei(500, "finney"),
+                );
+                for (const address of [getAccount(), fundOwner, beneficiary]) {
+                    for (const executor of [getAccount(), fundOwner]) {
+                        await assertFail(
+                            fund.receiveRefundTo(beneficiary, address, {
+                                from: executor,
+                            }),
+                            "Withdrawal from the deposit should be failed."
+                        );
+                    }
+                }
+            }
+        );
     }
 );


### PR DESCRIPTION
This patch adds some methods to selectively refund a purchase.  The feature purposes to prevent illegal investments or ban latent abusers.

The refund process consists of two steps:

1. Cancel one's contribution and deposit the ethers to be finally refund to them.  This step can be done by making a transaction to call `depositRefund()` method with the ethers to be refunded.  This transaction fails unless it's made by the token sale contract owner or the fund wallet.
2. A beneficiary *pulls* the deposited refund amount.  This step can be done by the following two ways:
    - To call `receiveRefund()` method by a beneficiary themselves, or the token sale contract owner.  In an ideal scenario, we can automate two steps by making a system calls `receiveRefund()` immediately after `depositRefund()`.  Such automation can simulate a user experience like refunded ethers are *pushed* to a beneficiary.
    - To call `receiveRefundTo()` method by a beneficiary themselves.  There can be scenarios that the address of a beneficiary turns out a smart contract, and in some ways it fails to receive ethers.  (See also [*Favor pull over push payments*][1] on *Onward with Ethereum Smart Contract Security*, a Zeppelin CTO's article.)  For such cases, it provides a *pull model* to refund, by having an additional parameter to take an address to receive ethers.

As this model of refund has a strong assumption on gradual delivery of tokens, I added these methods to `GradualDeliveryCrowdsale` contract rather than making a new abstract contract.

@jckdotim, @longfin, and @qria, please review the above scenarios and the implementation of that.

[1]: https://blog.zeppelin.solutions/onward-with-ethereum-smart-contract-security-97a827e47702#fa61