### PR TITLE
Events emission for applications

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,7 @@
     "mocha": true
   },
   "parserOptions": {
-    "ecmaVersion": 2017,
+    "ecmaVersion": 2018,
     "impliedStrict": true
   },
   "extends": "eslint:recommended",

--- a/contracts/CarryTokenPresale.sol
+++ b/contracts/CarryTokenPresale.sol
@@ -23,6 +23,8 @@ import "./GradualDeliveryCrowdsale.sol";
  * @dev The Carry token presale contract.
  */
 contract CarryTokenPresale is CarryTokenCrowdsale, GradualDeliveryCrowdsale {
+    using SafeMath for uint256;
+
     // FIXME: Here we've wanted to use constructor() keyword instead,
     // but solium/solhint lint softwares don't parse it properly as of
     // April 2018.
@@ -41,5 +43,13 @@ contract CarryTokenPresale is CarryTokenCrowdsale, GradualDeliveryCrowdsale {
         _individualMinPurchaseWei,
         _individualMaxCapWei
     ) {
+    }
+
+    function _transferRefund(address _beneficiary, address _wallet) internal {
+        uint256 depositedWeiAmount = refundedDeposits[_beneficiary];
+        super._transferRefund(_beneficiary, _wallet);
+        contributions[_beneficiary] = contributions[_beneficiary].sub(
+            depositedWeiAmount
+        );
     }
 }

--- a/contracts/GradualDeliveryCrowdsale.sol
+++ b/contracts/GradualDeliveryCrowdsale.sol
@@ -35,6 +35,18 @@ contract GradualDeliveryCrowdsale is Crowdsale, Ownable {
     address[] beneficiaries;
     mapping(address => uint256) public refundedDeposits;
 
+    event TokenDelivered(address indexed beneficiary, uint256 tokenAmount);
+    event RefundDeposited(
+        address indexed beneficiary,
+        uint256 tokenAmount,
+        uint256 weiAmount
+    );
+    event Refunded(
+        address indexed beneficiary,
+        address indexed receiver,
+        uint256 weiAmount
+    );
+
     /**
      * @dev Deliver only the given ratio of tokens to the beneficiaries.
      * For example, where there are two beneficiaries of each balance 90 CRE and
@@ -87,6 +99,7 @@ contract GradualDeliveryCrowdsale is Crowdsale, Ownable {
                 uint256 amount = balance.mul(_numerator).div(_denominator);
                 balances[beneficiary] = balance.sub(amount);
                 _deliverTokens(beneficiary, amount);
+                emit TokenDelivered(beneficiary, amount);
             }
         }
     }
@@ -115,6 +128,7 @@ contract GradualDeliveryCrowdsale is Crowdsale, Ownable {
         refundedDeposits[_beneficiary] = refundedDeposits[_beneficiary].add(
             weiToRefund
         );
+        emit RefundDeposited(_beneficiary, tokensToRefund, weiToRefund);
     }
 
     /**
@@ -154,5 +168,6 @@ contract GradualDeliveryCrowdsale is Crowdsale, Ownable {
         require(depositedWeiAmount > 0);
         refundedDeposits[_beneficiary] = 0;
         _wallet.transfer(depositedWeiAmount);
+        emit Refunded(_beneficiary, _wallet, depositedWeiAmount);
     }
 }

--- a/test/gradualDeliveryCrowdsale.js
+++ b/test/gradualDeliveryCrowdsale.js
@@ -382,6 +382,12 @@ multipleContracts(
                         web3.toWei(500, "finney"),
                         web3.toWei(500, "finney"),
                     );
+                    let previousContribution;
+                    if (contractName === "CarryTokenPresale") {
+                        previousContribution = await fund.contributions(
+                            beneficiary
+                        );
+                    }
                     const previousEther = web3.eth.getBalance(beneficiary);
                     const executor = getExecutor(beneficiary);
                     const result = await fund.receiveRefund(beneficiary, {
@@ -426,6 +432,15 @@ multipleContracts(
                             previousEther.plus(web3.toWei(500, "finney")),
                             web3.eth.getBalance(beneficiary),
                             "The purchased ethers should be completely refunded"
+                        );
+                    }
+                    if (contractName === "CarryTokenPresale") {
+                        assertEq(
+                            previousContribution.minus(
+                                web3.toWei(500, "finney")
+                            ),
+                            await fund.contributions(beneficiary),
+                            "Individual contribution should be subtracted"
                         );
                     }
                 }

--- a/test/utils.js
+++ b/test/utils.js
@@ -86,6 +86,13 @@ function assertNotEq(expected, actual, message) {
     );
 }
 
+function assertEvents(expectedEvents, result) {
+    assert.deepEqual(
+        expectedEvents,
+        result.logs.map(log => ({ $event: log.event, ...log.args }))
+    );
+}
+
 async function assertFail(promise, message) {
     let failed = false;
     try {
@@ -102,4 +109,5 @@ module.exports = {
     assertEq,
     assertNotEq,
     assertFail,
+    assertEvents,
 };


### PR DESCRIPTION
This patch defines the following three types of events for `GradualDeliveryCrowdsale` contract and makes them emitted so that applications can listen to these events:

- `TokenDelivered`
- `RefundDeposited`
- `Refunded`

The fields to represent a related address are indexed as well so that we can search transactions in the blockchain by these fields.

It also fixed a minor bug that refunds hadn't affected to the amount of individual contributions which purposes to limit their maximum ethers to purchase.