### PR TITLE
Proper delivery of tokens purchased multiple times

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This repository contains:
 
 - `GradualDeliveryCrowdsale` which declares the base contract for token
   crowdsale that does not deliver tokens to a beneficiary immediately after
-  they has just purchased, but instead partially delivers tokens through
+  they have just purchased, but instead partially delivers tokens through
   several times, and
 
 - `CarryTokenPresale` which declares the contract for the Carry token presale

--- a/contracts/CarryTokenCrowdsale.sol
+++ b/contracts/CarryTokenCrowdsale.sol
@@ -59,7 +59,7 @@ contract CarryTokenCrowdsale is WhitelistedCrowdsale, CappedCrowdsale {
 
         // If a contributor already has purchased a minimum amount, say 0.1 ETH,
         // then they can purchase once again with less than a minimum amount,
-        // say 0.01 ETH, because they has already satisfied the minimum
+        // say 0.01 ETH, because they have already satisfied the minimum
         // purchase.
         require(contributionAfterPurchase >= individualMinPurchaseWei);
 

--- a/contracts/GradualDeliveryCrowdsale.sol
+++ b/contracts/GradualDeliveryCrowdsale.sol
@@ -23,7 +23,7 @@ import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 /**
  * @title GradualDeliveryCrowdsale
  * @dev Crowdsale that does not deliver tokens to a beneficiary immediately
- * after they has just purchased, but instead partially delivers tokens through
+ * after they have just purchased, but instead partially delivers tokens through
  * several times when the contract owner calls deliverTokenRatio() method.
  * Note that it also provides methods to selectively refund some purchases.
  */

--- a/contracts/GradualDeliveryCrowdsale.sol
+++ b/contracts/GradualDeliveryCrowdsale.sol
@@ -24,7 +24,7 @@ import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
  * @title GradualDeliveryCrowdsale
  * @dev Crowdsale that does not deliver tokens to a beneficiary immediately
  * after they have just purchased, but instead partially delivers tokens through
- * several times when the contract owner calls deliverTokenRatio() method.
+ * several times when the contract owner calls deliverTokensInRatio() method.
  * Note that it also provides methods to selectively refund some purchases.
  */
 contract GradualDeliveryCrowdsale is Crowdsale, Ownable {
@@ -117,7 +117,7 @@ contract GradualDeliveryCrowdsale is Crowdsale, Ownable {
     }
     /**
      * @dev Refund the given ether to a beneficiary.  It only can be called by
-     * either the contract owner or the wallet (i.e. Crowdsale.wallet) address.
+     * either the contract owner or the wallet (i.e., Crowdsale.wallet) address.
      * The only amount of the ether sent together in a transaction is refunded.
      */
     function depositRefund(address _beneficiary) public payable {
@@ -149,7 +149,7 @@ contract GradualDeliveryCrowdsale is Crowdsale, Ownable {
     }
 
     /**
-     * @dev Similar to receiverRefund() except that it cannot be called by
+     * @dev Similar to receiveRefund() except that it cannot be called by
      * even the contract owner, but only the beneficiary of the refund.
      * It also takes an additional parameter, a wallet address to receiver
      * the deposited (refunded) ethers.

--- a/contracts/GradualDeliveryCrowdsale.sol
+++ b/contracts/GradualDeliveryCrowdsale.sol
@@ -108,8 +108,12 @@ contract GradualDeliveryCrowdsale is Crowdsale, Ownable {
         address _beneficiary,
         uint256 _tokenAmount
     ) internal {
-        beneficiaries.push(_beneficiary);
-        balances[_beneficiary] = balances[_beneficiary].add(_tokenAmount);
+        if (_tokenAmount > 0) {
+            if (balances[_beneficiary] <= 0) {
+                beneficiaries.push(_beneficiary);
+            }
+            balances[_beneficiary] = balances[_beneficiary].add(_tokenAmount);
+        }
     }
     /**
      * @dev Refund the given ether to a beneficiary.  It only can be called by

--- a/contracts/GradualDeliveryCrowdsale.sol
+++ b/contracts/GradualDeliveryCrowdsale.sol
@@ -70,29 +70,29 @@ contract GradualDeliveryCrowdsale is Crowdsale, Ownable {
      * @dev It's mostly same to deliverTokensInRatio(), except it processes
      * only a particular range of the list of beneficiaries.
      */
-    function deliverTokensInRatioFromTo(
+    function deliverTokensInRatioOfRange(
         uint256 _numerator,
         uint256 _denominator,
-        uint _from,
-        uint _to
+        uint _startIndex,
+        uint _endIndex
     ) external onlyOwner {
-        require(_from < _to);
-        _deliverTokensInRatio(_numerator, _denominator, _from, _to);
+        require(_startIndex < _endIndex);
+        _deliverTokensInRatio(_numerator, _denominator, _startIndex, _endIndex);
     }
 
     function _deliverTokensInRatio(
         uint256 _numerator,
         uint256 _denominator,
-        uint _from,
-        uint _to
+        uint _startIndex,
+        uint _endIndex
     ) internal {
         require(_denominator > 0);
         require(_numerator <= _denominator);
-        uint to = _to;
-        if (to > beneficiaries.length) {
-            to = beneficiaries.length;
+        uint endIndex = _endIndex;
+        if (endIndex > beneficiaries.length) {
+            endIndex = beneficiaries.length;
         }
-        for (uint i = _from; i < to; i = i.add(1)) {
+        for (uint i = _startIndex; i < endIndex; i = i.add(1)) {
             address beneficiary = beneficiaries[i];
             uint256 balance = balances[beneficiary];
             if (balance > 0) {

--- a/test/gradualDeliveryCrowdsale.js
+++ b/test/gradualDeliveryCrowdsale.js
@@ -172,9 +172,9 @@ multipleContracts(
                     from: contributors[i],
                 });
             }
-            const from = 2, to = 5;
-            const result = await fund.deliverTokensInRatioFromTo(
-                1, 2, from, to,
+            const startIndex = 2, endIndex = 5;
+            const result = await fund.deliverTokensInRatioOfRange(
+                1, 2, startIndex, endIndex,
                 {from: fundOwner}
             );
             const rate = await fund.rate();
@@ -183,13 +183,13 @@ multipleContracts(
                     $event: "TokenDelivered",
                     beneficiary: address,
                     tokenAmount: rate.mul(web3.toWei((i + 1) * 50, "finney")),
-                })).slice(from, to),
+                })).slice(startIndex, endIndex),
                 result
             );
             const finalBalances =
                 await Promise.all(contributors.map(c => token.balanceOf(c)));
             for (let i = 0; i < contributors.length; i++) {
-                if (from <= i && i < to) {
+                if (startIndex <= i && i < endIndex) {
                     assertEq(
                         rate.mul(web3.toWei(50, "finney")).mul(i + 1),
                         finalBalances[i].minus(initialBalances[i]),

--- a/test/gradualDeliveryCrowdsale.js
+++ b/test/gradualDeliveryCrowdsale.js
@@ -101,13 +101,25 @@ multipleContracts(
             ];
             assert.equal(etherAmounts.length, contributors.length);
             for (let i = 0; i < etherAmounts.length; i++) {
-                if (etherAmounts[i] < 1) {
-                    continue;
+                let amount = new web3.BigNumber(etherAmounts[i]);
+                while (amount > 0) {
+                    // This simultates situations that a single beneficiary
+                    // (account) purhcases tokens through multiple times of
+                    // Ether transfers.
+                    //
+                    // Whether a beneficiary (account) purchases the amount
+                    // of tokens through multiple times or at a time,
+                    // they and their rights should be treated alike.
+                    const chunkValue = web3.BigNumber.min(
+                        amount,
+                        web3.toWei(200, "finney")
+                    );
+                    await fund.sendTransaction({
+                        value: chunkValue,
+                        from: contributors[i],
+                    });
+                    amount = amount.minus(chunkValue);
                 }
-                await fund.sendTransaction({
-                    value: etherAmounts[i],
-                    from: contributors[i],
-                });
             }
             const intermediateBalances =
                 await Promise.all(contributors.map(c => token.balanceOf(c)));


### PR DESCRIPTION
This patch prevents the following vulnerability:

> Executing `beneficiaries.push(_beneficiary);` may lead to cases where beneficiaries are added multiple times, compromising the gradual delivery of tokens, as given by functions `deliverTokensInRatio()` and `deliverTokensInRatioFromTo()`.

Also renamed parameters `from`/`to` to`startIndex`/`endIndex` since these names can be confused for a source and a destination of a transfer.  The method `deliverTokensInRatioFromTo()` is renamed to `deliverTokensInRatioOfRange()` too.

Other changes are in comments.

@jckdotim @longfin @qria Could you review this?