### PR TITLE
Making the tokensale able to pause receiving ethers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ follows <https://ropsten.infura.io/> base URL.
 Last of all, with `MNEMONIC` and `ACCESS_TOKEN` environment variables
 the following command deploys all contracts to the public testnet:
 
-    MNEMONIC="..." ACCESS_TOKEN="..." truffle deploy --network demo
+    MNEMONIC="..." ACCESS_TOKEN="..." npx truffle deploy --network demo
 
 You must be able to find transactions made by your account from
 [Etherscan][Ropsten].

--- a/contracts/CarryTokenCrowdsale.sol
+++ b/contracts/CarryTokenCrowdsale.sol
@@ -17,6 +17,7 @@ pragma solidity ^0.4.23;
 
 import "openzeppelin-solidity/contracts/crowdsale/validation/CappedCrowdsale.sol";
 import "openzeppelin-solidity/contracts/crowdsale/validation/WhitelistedCrowdsale.sol";
+import "openzeppelin-solidity/contracts/lifecycle/Pausable.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "./CarryToken.sol";
 
@@ -25,7 +26,7 @@ import "./CarryToken.sol";
  * @dev The common base contract for both sales: the Carry token presale,
  * and the Carry token public crowdsale.
  */
-contract CarryTokenCrowdsale is WhitelistedCrowdsale, CappedCrowdsale {
+contract CarryTokenCrowdsale is WhitelistedCrowdsale, CappedCrowdsale, Pausable {
     using SafeMath for uint256;
 
     // Individual min and max purchases.
@@ -52,7 +53,7 @@ contract CarryTokenCrowdsale is WhitelistedCrowdsale, CappedCrowdsale {
     function _preValidatePurchase(
         address _beneficiary,
         uint256 _weiAmount
-    ) internal {
+    ) internal whenNotPaused {
         super._preValidatePurchase(_beneficiary, _weiAmount);
         uint256 contribution = contributions[_beneficiary];
         uint256 contributionAfterPurchase = contribution.add(_weiAmount);

--- a/package-lock.json
+++ b/package-lock.json
@@ -618,20 +618,12 @@
       }
     },
     "deasync": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.12.tgz",
-      "integrity": "sha512-gpacYo8FBZh3INBp2KOtrQp9kCO5faHvOmEZx3/cZTr3Mm8/kAYs7/Ws3E3OAH0ApBNK6Y6N+7+Dka2Zn2Fldw==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.13.tgz",
+      "integrity": "sha512-/6ngYM7AapueqLtvOzjv9+11N2fHDSrkxeMF1YPE20WIfaaawiBg+HZH1E5lHrcJxlKR42t6XPOEmMmqcAsU1g==",
       "requires": {
         "bindings": "1.2.1",
         "nan": "2.10.0"
-      }
-    },
-    "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "requires": {
-        "ms": "2.0.0"
       }
     },
     "decamelize": {
@@ -696,11 +688,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
-    "diff": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
     },
     "doctrine": {
       "version": "2.1.0",
@@ -1834,11 +1821,6 @@
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
     },
-    "growl": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8="
-    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -1868,11 +1850,6 @@
       "requires": {
         "ansi-regex": "2.1.1"
       }
-    },
-    "has-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
     },
     "hash-base": {
       "version": "3.0.4",
@@ -2283,11 +2260,6 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
-    "json3": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
-    },
     "jsonfile": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
@@ -2501,69 +2473,10 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
-    "lodash._baseassign": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
-      }
-    },
-    "lodash._basecopy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
-    },
-    "lodash._basecreate": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE="
-    },
-    "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
-    },
-    "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
-    },
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
-    },
-    "lodash.create": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._basecreate": "3.0.3",
-        "lodash._isiterateecall": "3.0.9"
-      }
-    },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-    },
-    "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
-      }
     },
     "lru-cache": {
       "version": "4.1.2",
@@ -2735,25 +2648,6 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
-      }
-    },
-    "mocha": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
-      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
-      "requires": {
-        "browser-stdout": "1.3.0",
-        "commander": "2.9.0",
-        "debug": "2.6.8",
-        "diff": "3.2.0",
-        "escape-string-regexp": "1.0.5",
-        "glob": "7.1.1",
-        "growl": "1.9.2",
-        "he": "1.1.1",
-        "json3": "3.3.2",
-        "lodash.create": "3.1.1",
-        "mkdirp": "0.5.1",
-        "supports-color": "3.1.2"
       }
     },
     "ms": {
@@ -3486,9 +3380,9 @@
       }
     },
     "solium": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/solium/-/solium-1.1.6.tgz",
-      "integrity": "sha512-hCZr5cEK2H6LVC1Lr7IGPGJ8Bs4Ktif9cmwnk3BHpoZLIwTtrNE0LUtTRBxkO3/G0GGB4OdxnnJT1pbgsJ/2Uw==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/solium/-/solium-1.1.7.tgz",
+      "integrity": "sha512-yYbalsrzJCU+QJ0HZvxAT4IQIqI1e6KPW2vop0NaHwdijqhQC9fJkVioCrL18NbO2Z8rdcnx8Y0JpvYJWrIjRg==",
       "requires": {
         "ajv": "5.5.2",
         "chokidar": "1.7.0",
@@ -3499,23 +3393,8 @@
         "sol-digger": "0.0.2",
         "sol-explore": "1.6.1",
         "solium-plugin-security": "0.1.1",
-        "solparse": "2.2.4",
+        "solparse": "2.2.5",
         "text-table": "0.2.0"
-      }
-    },
-    "solium-plugin-security": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/solium-plugin-security/-/solium-plugin-security-0.1.1.tgz",
-      "integrity": "sha512-kpLirBwIq4mhxk0Y/nn5cQ6qdJTI+U1LO3gpoNIcqNaW+sI058moXBe2UiHs+9wvF9IzYD49jcKhFTxcR9u9SQ=="
-    },
-    "solparse": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/solparse/-/solparse-2.2.4.tgz",
-      "integrity": "sha512-Sdyk983juUaOITdTD9U5Yc+MaX8kz4pN3wFyCRILWXW3+Ff96PxY9RLBuZINYbBgCAXN1a+kThJfFMlaXG9R6A==",
-      "requires": {
-        "mocha": "4.1.0",
-        "pegjs": "0.10.0",
-        "yargs": "10.1.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3537,11 +3416,6 @@
             "strip-ansi": "4.0.0",
             "wrap-ansi": "2.1.0"
           }
-        },
-        "commander": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
         },
         "debug": {
           "version": "3.1.0",
@@ -3607,6 +3481,13 @@
             "he": "1.1.1",
             "mkdirp": "0.5.1",
             "supports-color": "4.4.0"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "2.11.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+              "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+            }
           }
         },
         "os-locale": {
@@ -3617,6 +3498,16 @@
             "execa": "0.7.0",
             "lcid": "1.0.0",
             "mem": "1.1.0"
+          }
+        },
+        "solparse": {
+          "version": "2.2.5",
+          "resolved": "https://registry.npmjs.org/solparse/-/solparse-2.2.5.tgz",
+          "integrity": "sha512-t7tvtR6KU6QfPYLMv1nlCh9DA8HYIu5tbjHpKu0fhGFZ1NuSp0KKDHfFHv07g6v1xgcuUY3rVqNFjZt5b9+5qA==",
+          "requires": {
+            "mocha": "4.1.0",
+            "pegjs": "0.10.0",
+            "yargs": "10.1.2"
           }
         },
         "string-width": {
@@ -3677,6 +3568,11 @@
           }
         }
       }
+    },
+    "solium-plugin-security": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/solium-plugin-security/-/solium-plugin-security-0.1.1.tgz",
+      "integrity": "sha512-kpLirBwIq4mhxk0Y/nn5cQ6qdJTI+U1LO3gpoNIcqNaW+sI058moXBe2UiHs+9wvF9IzYD49jcKhFTxcR9u9SQ=="
     },
     "spdx-correct": {
       "version": "3.0.0",
@@ -3793,14 +3689,6 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
-    "supports-color": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-      "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-      "requires": {
-        "has-flag": "1.0.0"
-      }
-    },
     "table": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
@@ -3915,13 +3803,93 @@
       "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
     },
     "truffle": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/truffle/-/truffle-4.1.7.tgz",
-      "integrity": "sha512-fe6BIcD9xo6iIJvV1m6ZhOk56kmB8k38kdoWOKYnPPw7ZUUSupgojeTb2K5e+4qIpIHvEvmET4yLUjSGR+hvwA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/truffle/-/truffle-4.1.11.tgz",
+      "integrity": "sha512-VNhc6jexZeM92sNJJr4U8ln3uJ/mJEQO/0y9ZLYc4pccyIskPtl+3r4mzymgGM/Mq5v6MpoQVD6NZgHUVKX+Dw==",
       "requires": {
-        "mocha": "3.5.3",
+        "mocha": "4.1.0",
         "original-require": "1.0.1",
-        "solc": "0.4.23"
+        "solc": "0.4.24"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "diff": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+          "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "growl": {
+          "version": "1.10.3",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+          "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+        },
+        "mocha": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+          "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+          "requires": {
+            "browser-stdout": "1.3.0",
+            "commander": "2.11.0",
+            "debug": "3.1.0",
+            "diff": "3.3.1",
+            "escape-string-regexp": "1.0.5",
+            "glob": "7.1.2",
+            "growl": "1.10.3",
+            "he": "1.1.1",
+            "mkdirp": "0.5.1",
+            "supports-color": "4.4.0"
+          }
+        },
+        "solc": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.24.tgz",
+          "integrity": "sha512-2xd7Cf1HeVwrIb6Bu1cwY2/TaLRodrppCq3l7rhLimFQgmxptXhTC3+/wesVLpB09F1A2kZgvbMOgH7wvhFnBQ==",
+          "requires": {
+            "fs-extra": "0.30.0",
+            "memorystream": "0.3.1",
+            "require-from-string": "1.2.1",
+            "semver": "5.5.0",
+            "yargs": "4.8.1"
+          }
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
       }
     },
     "truffle-hdwallet-provider": {

--- a/test/carryTokenCrowdsale.js
+++ b/test/carryTokenCrowdsale.js
@@ -149,5 +149,23 @@ multipleContracts(
                 from: contributor,
             });
         });
+
+        it("should not receive ethers if it is paused", async () => {
+            const contributor = getAccount();
+            const fund = getFund();
+            await fund.addToWhitelist(contributor, {from: fundOwner});
+            await fund.pause({from: fundOwner});
+            await assertFail(
+                fund.sendTransaction({
+                    value: web3.toWei(100, "finney"),
+                    from: contributor,
+                })
+            );
+            await fund.unpause({from: fundOwner});
+            await fund.sendTransaction({
+                value: web3.toWei(100, "finney"),
+                from: contributor,
+            });
+        });
     }
 );


### PR DESCRIPTION
As there is a certain limit to the amount of gas that a transaction can consume at most, and the more addresses [`addManyToWhitelist()`][1] takes, the more gas it consumes, we virtually cannot add a lot of addresses to the whitelist at a time.

If we make multiple transactions to split addresses into chunks, these became likely to be included to different blocks in the network.  It's unfair to become available to purchase at different times.

If the tokensale can pause receiving ethers the problem can be mitigated by the following process:

1. Pauses the tokensale so that nobody can purchase tokens until it's unpaused again.
2. Adds a lot of addresses to the whitelist.
3. Unpause the tokensale so that it's available to purchase tokens to everybody, at the same time.

This patch is not complex in itself; it leverages OpenZeppelin's lifecycle mixin [`Pausable`][2] and makes the tokensale contract receive ethers only when not paused.

I made a side commit which is trivial as well; this merely upgrades dependencies in the lockfile and adjusts a typo.

@jckdotim @longfin @qria Could you review this?

[1]: https://openzeppelin.org/api/docs/crowdsale_validation_WhitelistedCrowdsale.html#addManyToWhitelist
[2]: https://openzeppelin.org/api/docs/lifecycle_Pausable.html