### PR TITLE
Make the Carry token burnable

### DIFF
--- a/contracts/CarryToken.sol
+++ b/contracts/CarryToken.sol
@@ -15,10 +15,11 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 pragma solidity ^0.4.23;
 
+import "openzeppelin-solidity/contracts/token/ERC20/BurnableToken.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/CappedToken.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/PausableToken.sol";
 
-contract CarryToken is PausableToken, CappedToken {
+contract CarryToken is PausableToken, CappedToken, BurnableToken {
     string public name = "CarryToken";
     string public symbol = "CRE";
     uint8 public decimals = 18;


### PR DESCRIPTION
Since <q>All unsold tokens will be burned</q> according to [Carry's token metrics][1], we need to make the `CarryToken` contract can burn tokens.  This patch change it to inherit OpenZeppelin's [`BurnableToken`][2] which exactly purposes that.

@jckdotim @longfin @qria Please review this.

[1]: https://carryprotocol.io/#section-token-metrics
[2]: https://openzeppelin.org/api/docs/token_ERC20_BurnableToken.html