### PR TITLE
Limit the maximum gas price to prevent gas war

### DIFF
--- a/contracts/CarryTokenCrowdsale.sol
+++ b/contracts/CarryTokenCrowdsale.sol
@@ -29,6 +29,8 @@ import "./CarryToken.sol";
 contract CarryTokenCrowdsale is WhitelistedCrowdsale, CappedCrowdsale, Pausable {
     using SafeMath for uint256;
 
+    uint256 constant maxGasPrice = 40000000000;  // 40 gwei
+
     // Individual min and max purchases.
     uint256 public individualMinPurchaseWei;
     uint256 public individualMaxCapWei;
@@ -54,6 +56,9 @@ contract CarryTokenCrowdsale is WhitelistedCrowdsale, CappedCrowdsale, Pausable 
         address _beneficiary,
         uint256 _weiAmount
     ) internal whenNotPaused {
+        // Prevent gas war among purchasers.
+        require(tx.gasprice <= maxGasPrice);
+
         super._preValidatePurchase(_beneficiary, _weiAmount);
         uint256 contribution = contributions[_beneficiary];
         uint256 contributionAfterPurchase = contribution.add(_weiAmount);

--- a/test/carryTokenCrowdsale.js
+++ b/test/carryTokenCrowdsale.js
@@ -167,5 +167,20 @@ multipleContracts(
                 from: contributor,
             });
         });
+
+        it("rejects TXes paying more than 40 gwei for gas price", async () => {
+            const maxGasPrice = new web3.BigNumber(web3.toWei(40, "gwei"));
+            const contributor = getAccount();
+            const fund = getFund();
+            await fund.addToWhitelist(contributor, {from: fundOwner});
+            await assertFail(
+                fund.sendTransaction({
+                    value: web3.toWei(100, "finney"),
+                    from: contributor,
+                    gasPrice: maxGasPrice.plus(1),
+                }),
+                "The TX paying more than 40 gwei for gas price should fail."
+            );
+        });
     }
 );

--- a/test/utils.js
+++ b/test/utils.js
@@ -5,6 +5,10 @@ function multipleContracts(contracts, callback) {
         const CarryToken = artifacts.require("CarryToken");
         const Contract = artifacts.require(contractName);
 
+        Contract.defaults({
+            gasPrice: 40000000000,  // 40 gwei
+        });
+
         contract(contractName, async function (accounts) {
             const reservedAccounts = 1;
             let accountIndex = reservedAccounts;


### PR DESCRIPTION
In order to prevent gas war among purchasers, this patch sets the maximum gas price and makes transactions paying more than the maximum rejected.

@jckdotim @longfin @qria Please review this.