### PR TITLE
Deploy CarryToken from a distinct account

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ Alternatively, raw `PRIVATE_KEY` can be used instead of `MNEMONIC`:
 Note that `PRIVATE_KEY` can contain multiple private keys separated by
 whitespace.
 
+In order to deploy the `CarryToken` contract using a different owner account,
+configure `TOKEN_OWNER` environment variable.  It has to be a public key of
+the owner account, and either `MNEMONIC` or `PRIVATE_KEY` have to contain
+its corresponding private part.
+
+    TOKEN_OWNER="..." MNEMONIC="..." ACCESS_TOKEN="..." npx truffle deploy --network demo
+
 You must be able to find transactions made by your account from
 [Etherscan][Ropsten].
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ Alternatively, raw `PRIVATE_KEY` can be used instead of `MNEMONIC`:
 
     PRIVATE_KEY="..." ACCESS_TOKEN="..." npx truffle deploy --network demo
 
+Note that `PRIVATE_KEY` can contain multiple private keys separated by
+whitespace.
+
 You must be able to find transactions made by your account from
 [Etherscan][Ropsten].
 

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -40,8 +40,18 @@ const presale = {
 };
 
 module.exports = (deployer, network, accounts) => {
+    const tokenOwner =
+        process.env.TOKEN_OWNER
+            ? process.env.TOKEN_OWNER.toLowerCase()
+            : accounts[0];
+    if (!accounts.includes(tokenOwner)) {
+        throw new Error(
+            "No private key is available for the account " + tokenOwner +
+            "; available accounts are: " + accounts.join(", ")
+        );
+    }
     let carryToken;
-    deployer.deploy(CarryToken).then(() => {
+    deployer.deploy(CarryToken, { from: tokenOwner }).then(() => {
         return CarryToken.deployed();
     }).then((_carryToken) => {
         carryToken = _carryToken;
@@ -60,7 +70,7 @@ module.exports = (deployer, network, accounts) => {
         return carryToken.mint(
             carryTokenPresale.address,
             new web3.BigNumber(presale.cap).mul(presale.rate),
-            {from: accounts[0]}
+            {from: tokenOwner}
         );
     });
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4809,9 +4809,8 @@
       }
     },
     "truffle-hdwallet-provider-privkey": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/truffle-hdwallet-provider-privkey/-/truffle-hdwallet-provider-privkey-0.2.0.tgz",
-      "integrity": "sha512-p4dCmB/roQaHaRMe7Ihej4/Cdmq7Usi6aZsPv/cc2x7S5bYLSwwpgQBdjz4PjPSgNh8zqLte6ZhWkkW1CEq1iQ==",
+      "version": "https://github.com/rhlsthrm/truffle-hdwallet-provider-privkey/archive/c226346761ea0dac05d59824cb0a6bd785022e55.tar.gz",
+      "integrity": "sha512-VjwNS3C5nn5YA7JUhwgKMdu6CG/YXdxMd4xJmEPB5kC/bwSVge81Ylh8pqN6cbSogmMdTRh/8iM4RVgyTmWeww==",
       "requires": {
         "ethereumjs-tx": "1.3.4",
         "ethereumjs-wallet": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "solium": "^1.1.6",
     "truffle": "^4.1.7",
     "truffle-hdwallet-provider": "0.0.3",
-    "truffle-hdwallet-provider-privkey": "^0.2.0"
+    "truffle-hdwallet-provider-privkey": "https://github.com/rhlsthrm/truffle-hdwallet-provider-privkey/archive/c226346761ea0dac05d59824cb0a6bd785022e55.tar.gz"
   },
   "private": true
 }

--- a/truffle.js
+++ b/truffle.js
@@ -35,14 +35,14 @@ const networkCandidates = {
         provider: () => {
             const {
                 MNEMONIC: mnemonic,
-                PRIVATE_KEY: privateKey,
+                PRIVATE_KEY: privateKeys,
                 ACCESS_TOKEN: accessToken,
             } = process.env;
-            if (mnemonic == null && privateKey == null) {
+            if (mnemonic == null && privateKeys == null) {
                 throw new Error(
                     "Missing environment variable: MNEMONIC or PRIVATE_KEY"
                 );
-            } else if (mnemonic != null && privateKey != null) {
+            } else if (mnemonic != null && privateKeys != null) {
                 throw new Error(
                     "MNEMONIC & PRIVATE_KEY are mutually exclusive"
                 );
@@ -56,7 +56,17 @@ const networkCandidates = {
             if (mnemonic != null) {
                 return new HDWalletProvider(mnemonic, url);
             }
-            return new HDWalletProviderPrivkey(privateKey.toLowerCase(), url);
+            const privateKeyArray = privateKeys
+                .trim().split(/\s+/g)
+                .map(k => {
+                    if (!k.match(/^[0-9a-f]+$/i)) {
+                        throw new Error(
+                            "Invalid private key: " + k
+                        );
+                    }
+                    return k.toLowerCase();
+                });
+            return new HDWalletProviderPrivkey(privateKeyArray, url);
         },
         gas: 2900000,
         network_id: 3


### PR DESCRIPTION
Whereas the owner account of a `CarryTokenPresale` contract has only permission to touch its whitelist or pause/resume the tokensale, the owner account of a `CarryToken` contract has a permission to mint new tokens.  As two types of permissions have quite different powers, two permissions should be separately assigned to two different accounts.

This patch adds an optional configuration through `TOKEN_OWNER` environment variable to give the ownership of a `CarryToken` contract to the other account than the default account (i.e., `accounts[0]`).

In order to make transactions in the name of more than one account, it also need to take multiple private keys.  Although a `MNEMONIC` can contain multiple private keys, `PRIVATE_KEY` had been possible to take only one account.  This patch also change `PRIVATE_KEY` configuration to take space-separated multiple private keys.

See also the changes on the *README.md* file.

@jckdotim @longfin @qria Please review this.