### PR TITLE
Work around Infura's non-sticky nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ its corresponding private part.
 
     TOKEN_OWNER="..." MNEMONIC="..." ACCESS_TOKEN="..." npx truffle deploy --network demo
 
+[Since Infura has a load balancer in front of their nodes, the deployment
+transactions can be intermittently falling out of sync.][3]  In order to
+work around this problem, `DELAY_SECONDS` environment variable can configure
+the interval to delay between transactions:
+
+    DELAY_SECONDS=60 MNEMONIC="..." ACCESS_TOKEN="..." npx truffle deploy --network demo
+
 You must be able to find transactions made by your account from
 [Etherscan][Ropsten].
 
@@ -107,6 +114,7 @@ You must be able to find transactions made by your account from
 [Geth]: https://github.com/ethereum/go-ethereum
 [1]: http://faucet.ropsten.be:3001/
 [2]: https://faucet.bitfwd.xyz/
+[3]: https://github.com/trufflesuite/truffle-migrate/issues/29
 
 
 License

--- a/migrations/1_initial_migration.js
+++ b/migrations/1_initial_migration.js
@@ -16,5 +16,10 @@
 const Migrations = artifacts.require("./Migrations.sol");
 
 module.exports = (deployer) => {
-    return deployer.deploy(Migrations);
+    let delay = 0;
+    if ((process.env.DELAY_SECONDS || "").match(/^\d+$/)) {
+        delay = process.env.DELAY_SECONDS * 1000;
+    }
+    return deployer.deploy(Migrations)
+        .then(c => new Promise(resolve => setTimeout(() => resolve(c), delay)));
 };

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -40,6 +40,10 @@ const presale = {
 };
 
 module.exports = (deployer, network, accounts) => {
+    let delay = 0;
+    if ((process.env.DELAY_SECONDS || "").match(/^\d+$/)) {
+        delay = process.env.DELAY_SECONDS * 1000;
+    }
     const tokenOwner =
         process.env.TOKEN_OWNER
             ? process.env.TOKEN_OWNER.toLowerCase()
@@ -51,7 +55,9 @@ module.exports = (deployer, network, accounts) => {
         );
     }
     let carryToken;
-    deployer.deploy(CarryToken, { from: tokenOwner }).then(() => {
+    deployer.deploy(CarryToken, { from: tokenOwner }).then(c => {
+        return new Promise(resolve => setTimeout(() => resolve(c), delay));
+    }).then(() => {
         return CarryToken.deployed();
     }).then((_carryToken) => {
         carryToken = _carryToken;
@@ -64,6 +70,8 @@ module.exports = (deployer, network, accounts) => {
             presale.individualMinPurchaseWei,
             presale.individualMaxCapWei
         );
+    }).then(c => {
+        return new Promise(resolve => setTimeout(() => resolve(c), delay));
     }).then(() => {
         return CarryTokenPresale.deployed();
     }).then((carryTokenPresale) => {
@@ -72,5 +80,7 @@ module.exports = (deployer, network, accounts) => {
             new web3.BigNumber(presale.cap).mul(presale.rate),
             {from: tokenOwner}
         );
+    }).then(c => {
+        return new Promise(resolve => setTimeout(() => resolve(c), delay));
     });
 };


### PR DESCRIPTION
This patch add an optional `DELAY_SECONDS` configuration to wait some seconds between deployment transactions.  The configuration purposes to work around [Infura's non-sticky nodes][1]:

> It's caused by Infura running a load-balancer in front of their nodes and the transactions intermittently falling out of sync as a result.

@jckdotim @longfin @qria Please review this.

[1]: https://github.com/trufflesuite/truffle-migrate/issues/29