### PR TITLE
Add “mainnet” option to available networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ follows <https://ropsten.infura.io/> base URL.
 Last of all, with `MNEMONIC` and `ACCESS_TOKEN` environment variables
 the following command deploys all contracts to the public testnet:
 
-    MNEMONIC="..." ACCESS_TOKEN="..." npx truffle deploy --network demo
+    MNEMONIC="..." ACCESS_TOKEN="..." npx truffle deploy --network ropsten
 
 Alternatively, raw `PRIVATE_KEY` can be used instead of `MNEMONIC`:
 
-    PRIVATE_KEY="..." ACCESS_TOKEN="..." npx truffle deploy --network demo
+    PRIVATE_KEY="..." ACCESS_TOKEN="..." npx truffle deploy --network ropsten
 
 Note that `PRIVATE_KEY` can contain multiple private keys separated by
 whitespace.
@@ -97,14 +97,14 @@ configure `TOKEN_OWNER` environment variable.  It has to be a public key of
 the owner account, and either `MNEMONIC` or `PRIVATE_KEY` have to contain
 its corresponding private part.
 
-    TOKEN_OWNER="..." MNEMONIC="..." ACCESS_TOKEN="..." npx truffle deploy --network demo
+    TOKEN_OWNER="..." MNEMONIC="..." ACCESS_TOKEN="..." npx truffle deploy --network ropsten
 
 [Since Infura has a load balancer in front of their nodes, the deployment
 transactions can be intermittently falling out of sync.][3]  In order to
 work around this problem, `DELAY_SECONDS` environment variable can configure
 the interval to delay between transactions:
 
-    DELAY_SECONDS=60 MNEMONIC="..." ACCESS_TOKEN="..." npx truffle deploy --network demo
+    DELAY_SECONDS=120 MNEMONIC="..." ACCESS_TOKEN="..." npx truffle deploy --network ropsten
 
 You must be able to find transactions made by your account from
 [Etherscan][Ropsten].
@@ -115,6 +115,15 @@ You must be able to find transactions made by your account from
 [1]: http://faucet.ropsten.be:3001/
 [2]: https://faucet.bitfwd.xyz/
 [3]: https://github.com/trufflesuite/truffle-migrate/issues/29
+
+
+Deploy to the public main network through [Infura]
+--------------------------------------------------
+
+It's almost the same to Ropsten, except that `--network ropsten` options in
+all commands have to be replaced by `--network mainnet`, e.g.:
+
+    MNEMONIC="..." ACCESS_TOKEN="..." npx truffle deploy --network mainnet
 
 
 License

--- a/scripts/whitelist.js
+++ b/scripts/whitelist.js
@@ -22,7 +22,7 @@ const CarryTokenPresale = artifacts.require("CarryTokenPresale");
 // 
 //     WHITELIST_FILE="..." \
 //     MNEMONIC="..." \
-//     npx truffle exec scripts/whitelist.js --network demo
+//     npx truffle exec scripts/whitelist.js --network ropsten
 //
 // See also Truffle's docs:
 //


### PR DESCRIPTION
This patch is already used for the previous deployment.  It adds `mainnet` to available `--network` options.  Also renamed the option `demo` to `ropsten` to make it clear.

@jckdotim @longfin @qria Can you guys review this?