### PR TITLE
Public tokensale & timed individual caps

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ This repository contains:
 - `CarryToken` contract which declares the **CRE** token based on
   [OpenZeppelin]'s [`CappedToken`][CappedToken] contract,
 
-- `CarryTokenCrowdsale` which declares the common base contract for token
-  crowdsale and is based on [OpenZeppelin]'s [`CappedCrowdsale`][CappedCrowdsale]
+- `CarryTokenPresaleBase` which declares the common base contract for token
+  presale and is based on [OpenZeppelin]'s [`CappedCrowdsale`][CappedCrowdsale]
   & [`WhitelistedCrowdsale`][WhitelistedCrowdsale] contracts, to be used for
-  the Carry token presale & public sale,
+  the Carry token presale,
 
 - `GradualDeliveryCrowdsale` which declares the base contract for token
   crowdsale that does not deliver tokens to a beneficiary immediately after

--- a/contracts/CarryPublicTokenCrowdsale.sol
+++ b/contracts/CarryPublicTokenCrowdsale.sol
@@ -57,14 +57,11 @@ contract CarryPublicTokenCrowdsale is CappedCrowdsale, Pausable {
 
     mapping(address => uint256) public contributions;
 
-    uint256 public closingTime;
-
     constructor(
         address _wallet,
         CarryToken _token,
         uint256 _rate,
         uint256 _cap,
-        uint256 _closingTime,
         uint256 _individualMinPurchaseWei,
 
         // Since Solidity currently doesn't allows parameters to take array of
@@ -77,7 +74,6 @@ contract CarryPublicTokenCrowdsale is CappedCrowdsale, Pausable {
             _individualMaxCaps.length % 2 == 0,
             "The length of _individualMaxCaps has to be even, not odd."
         );
-        closingTime = _closingTime;
         individualMinPurchaseWei = _individualMinPurchaseWei;
         for (uint256 i = 0; i < _individualMaxCaps.length; i += 2) {
             individualMaxCaps.push(
@@ -100,13 +96,6 @@ contract CarryPublicTokenCrowdsale is CappedCrowdsale, Pausable {
         );
 
         super._preValidatePurchase(_beneficiary, _weiAmount);
-
-        // Tokensale is closed after closingTime.
-        require(
-            // solium-disable-next-line security/no-block-members
-            block.timestamp <= closingTime,
-            "Already closed; it's too late."
-        );
 
         uint256 contribution = contributions[_beneficiary];
         uint256 contributionAfterPurchase = contribution.add(_weiAmount);
@@ -133,7 +122,9 @@ contract CarryPublicTokenCrowdsale is CappedCrowdsale, Pausable {
         }
         require(
             contributionAfterPurchase <= individualMaxWei,
-            "Total ethers you've purchased is too much."
+            individualMaxWei > 0
+                ? "Total ethers you've purchased is too much."
+                : "Purchase is currently disallowed."
         );
     }
 

--- a/contracts/CarryPublicTokenCrowdsale.sol
+++ b/contracts/CarryPublicTokenCrowdsale.sol
@@ -1,0 +1,141 @@
+// The Carry token and the tokensale contracts
+// Copyright (C) 2018 Carry Protocol
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+pragma solidity ^0.4.24;
+
+import "openzeppelin-solidity/contracts/crowdsale/validation/CappedCrowdsale.sol";
+import "openzeppelin-solidity/contracts/lifecycle/Pausable.sol";
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import "./CarryToken.sol";
+
+/**
+ * @title CarryTokenCrowdsale
+ * @dev The common base contract for both sales: the Carry token presale,
+ * and the Carry token public crowdsale.
+ */
+contract CarryPublicTokenCrowdsale is CappedCrowdsale, Pausable {
+    using SafeMath for uint256;
+
+    // Individual min purchases.
+    uint256 public individualMinPurchaseWei;
+
+    struct IndividualMaxCap {
+        uint256 timestamp;
+        uint256 maxWei;
+    }
+
+    // Individual max purchases differ by time.  The mapping keys are timestamps
+    // and values are weis an individual can purchase at most
+    // If the transaction is made later than a timestamp it can accept
+    // the corresponding cap at most.
+    //
+    // Where individualMaxCaps = [
+    //   IndividualMaxCap(1533081600000, 5 ether),
+    //   IndividualMaxCap(1533686400000, 10 ehter)
+    // ]
+    // If a transaction is made before 1533081600000 (2018-08-01 sharp UTC)
+    // it disallows any purchase.
+    // If a transaction is made between 1533081600000 (2018-08-01 sharp UTC)
+    // 1533686400000 (2018-08-15 sharp UTC) it takes 5 ethers at most.
+    // If a transaction is made after 1533686400000 (2018-08-15 sharp UTC)
+    // it takes 10 ethers at most.
+    IndividualMaxCap[] public individualMaxCaps;
+
+    mapping(address => uint256) public contributions;
+
+    uint256 public closingTime;
+
+    constructor(
+        address _wallet,
+        CarryToken _token,
+        uint256 _rate,
+        uint256 _cap,
+        uint256 _closingTime,
+        uint256 _individualMinPurchaseWei,
+
+        // Since Solidity currently doesn't allows parameters to take array of
+        // structs, we work around this by taking (timestamp, weis) pairs as
+        // a 1d-array of [timestamp1, weis1, timestamp2, weis2, ...].
+        // It fails if the length is not even but odd.
+        uint256[] _individualMaxCaps
+    ) public CappedCrowdsale(_cap) Crowdsale(_rate, _wallet, _token) {
+        require(
+            _individualMaxCaps.length % 2 == 0,
+            "The length of _individualMaxCaps has to be even, not odd."
+        );
+        closingTime = _closingTime;
+        individualMinPurchaseWei = _individualMinPurchaseWei;
+        for (uint256 i = 0; i < _individualMaxCaps.length; i += 2) {
+            individualMaxCaps.push(
+                IndividualMaxCap(
+                    _individualMaxCaps[i],
+                    _individualMaxCaps[i + 1]
+                )
+            );
+        }
+    }
+
+    function _preValidatePurchase(
+        address _beneficiary,
+        uint256 _weiAmount
+    ) internal whenNotPaused {
+        super._preValidatePurchase(_beneficiary, _weiAmount);
+
+        // Tokensale is closed after closingTime.
+        require(
+            // solium-disable-next-line security/no-block-members
+            block.timestamp <= closingTime,
+            "Already closed; it's too late."
+        );
+
+        uint256 contribution = contributions[_beneficiary];
+        uint256 contributionAfterPurchase = contribution.add(_weiAmount);
+
+        // If a contributor already has purchased a minimum amount, say 0.1 ETH,
+        // then they can purchase once again with less than a minimum amount,
+        // say 0.01 ETH, because they have already satisfied the minimum
+        // purchase.
+        require(
+            contributionAfterPurchase >= individualMinPurchaseWei,
+            "Sent ethers is not enough."
+        );
+
+        // See also the comment on the individualMaxCaps above.
+        uint256 latestTimestamp = 0;
+        uint256 individualMaxWei = 0;
+        for (uint256 i = 0; i < individualMaxCaps.length; i++) {
+            // solium-disable-next-line security/no-block-members
+            if (individualMaxCaps[i].timestamp <= block.timestamp &&
+                individualMaxCaps[i].timestamp > latestTimestamp) {
+                latestTimestamp = individualMaxCaps[i].timestamp;
+                individualMaxWei = individualMaxCaps[i].maxWei;
+            }
+        }
+        require(
+            contributionAfterPurchase <= individualMaxWei,
+            "Total ethers you've purchased is too much."
+        );
+    }
+
+    function _updatePurchasingState(
+        address _beneficiary,
+        uint256 _weiAmount
+    ) internal {
+        super._updatePurchasingState(_beneficiary, _weiAmount);
+        contributions[_beneficiary] = contributions[_beneficiary].add(
+            _weiAmount
+        );
+    }
+}

--- a/contracts/CarryPublicTokenCrowdsale.sol
+++ b/contracts/CarryPublicTokenCrowdsale.sol
@@ -44,14 +44,14 @@ contract CarryPublicTokenCrowdsale is CappedCrowdsale, Pausable {
     // the corresponding cap at most.
     //
     // Where individualMaxCaps = [
-    //   IndividualMaxCap(1533081600000, 5 ether),
-    //   IndividualMaxCap(1533686400000, 10 ehter)
+    //   IndividualMaxCap(1533081600, 5 ether),
+    //   IndividualMaxCap(1533686400, 10 ehter)
     // ]
-    // If a transaction is made before 1533081600000 (2018-08-01 sharp UTC)
+    // If a transaction is made before 1533081600 (2018-08-01 sharp UTC)
     // it disallows any purchase.
-    // If a transaction is made between 1533081600000 (2018-08-01 sharp UTC)
-    // 1533686400000 (2018-08-15 sharp UTC) it takes 5 ethers at most.
-    // If a transaction is made after 1533686400000 (2018-08-15 sharp UTC)
+    // If a transaction is made between 1533081600 (2018-08-01 sharp UTC)
+    // 1533686400 (2018-08-15 sharp UTC) it takes 5 ethers at most.
+    // If a transaction is made after 1533686400 (2018-08-15 sharp UTC)
     // it takes 10 ethers at most.
     IndividualMaxCap[] public individualMaxCaps;
 

--- a/contracts/CarryPublicTokenCrowdsale.sol
+++ b/contracts/CarryPublicTokenCrowdsale.sol
@@ -28,6 +28,8 @@ import "./CarryToken.sol";
 contract CarryPublicTokenCrowdsale is CappedCrowdsale, Pausable {
     using SafeMath for uint256;
 
+    uint256 constant maxGasPrice = 40000000000;  // 40 gwei
+
     // Individual min purchases.
     uint256 public individualMinPurchaseWei;
 
@@ -91,6 +93,12 @@ contract CarryPublicTokenCrowdsale is CappedCrowdsale, Pausable {
         address _beneficiary,
         uint256 _weiAmount
     ) internal whenNotPaused {
+        // Prevent gas war among purchasers.
+        require(
+            tx.gasprice <= maxGasPrice,
+            "Gas price is too expensive. Don't be competitive."
+        );
+
         super._preValidatePurchase(_beneficiary, _weiAmount);
 
         // Tokensale is closed after closingTime.

--- a/contracts/CarryPublicTokenCrowdsale.sol
+++ b/contracts/CarryPublicTokenCrowdsale.sol
@@ -45,7 +45,7 @@ contract CarryPublicTokenCrowdsale is CappedCrowdsale, Pausable {
     //
     // Where individualMaxCaps = [
     //   IndividualMaxCap(1533081600, 5 ether),
-    //   IndividualMaxCap(1533686400, 10 ehter)
+    //   IndividualMaxCap(1533686400, 10 ether)
     // ]
     // If a transaction is made before 1533081600 (2018-08-01 sharp UTC)
     // it disallows any purchase.

--- a/contracts/CarryPublicTokenCrowdsale.sol
+++ b/contracts/CarryPublicTokenCrowdsale.sol
@@ -21,9 +21,8 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "./CarryToken.sol";
 
 /**
- * @title CarryTokenCrowdsale
- * @dev The common base contract for both sales: the Carry token presale,
- * and the Carry token public crowdsale.
+ * @title CarryPublicTokenCrowdsale
+ * @dev The Carry token public sale contract.
  */
 contract CarryPublicTokenCrowdsale is CappedCrowdsale, Pausable {
     using SafeMath for uint256;

--- a/contracts/CarryPublicTokenCrowdsale.sol
+++ b/contracts/CarryPublicTokenCrowdsale.sol
@@ -50,8 +50,8 @@ contract CarryPublicTokenCrowdsale is CappedCrowdsale, Pausable {
     // If a transaction is made before 1533081600 (2018-08-01 sharp UTC)
     // it disallows any purchase.
     // If a transaction is made between 1533081600 (2018-08-01 sharp UTC)
-    // 1533686400 (2018-08-15 sharp UTC) it takes 5 ethers at most.
-    // If a transaction is made after 1533686400 (2018-08-15 sharp UTC)
+    // 1533686400 (2018-08-08 sharp UTC) it takes 5 ethers at most.
+    // If a transaction is made after 1533686400 (2018-08-08 sharp UTC)
     // it takes 10 ethers at most.
     IndividualMaxCap[] public individualMaxCaps;
 

--- a/contracts/CarryToken.sol
+++ b/contracts/CarryToken.sol
@@ -28,9 +28,6 @@ contract CarryToken is PausableToken, CappedToken, BurnableToken {
     //                10 billion <---------|   |-----------------> 10^18
     uint256 constant TOTAL_CAP = 10000000000 * 1000000000000000000;
 
-    // FIXME: Here we've wanted to use constructor() keyword instead,
-    // but solium/solhint lint softwares don't parse it properly as of
-    // April 2018.
-    function CarryToken() public CappedToken(TOTAL_CAP) {
+    constructor() public CappedToken(TOTAL_CAP) {
     }
 }

--- a/contracts/CarryToken.sol
+++ b/contracts/CarryToken.sol
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "openzeppelin-solidity/contracts/token/ERC20/BurnableToken.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/CappedToken.sol";

--- a/contracts/CarryTokenCrowdsale.sol
+++ b/contracts/CarryTokenCrowdsale.sol
@@ -37,10 +37,7 @@ contract CarryTokenCrowdsale is WhitelistedCrowdsale, CappedCrowdsale, Pausable 
 
     mapping(address => uint256) public contributions;
 
-    // FIXME: Here we've wanted to use constructor() keyword instead,
-    // but solium/solhint lint softwares don't parse it properly as of
-    // April 2018.
-    function CarryTokenCrowdsale(
+    constructor(
         address _wallet,
         CarryToken _token,
         uint256 _rate,

--- a/contracts/CarryTokenPresale.sol
+++ b/contracts/CarryTokenPresale.sol
@@ -15,14 +15,14 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 pragma solidity ^0.4.23;
 
-import "./CarryTokenCrowdsale.sol";
+import "./CarryTokenPresaleBase.sol";
 import "./GradualDeliveryCrowdsale.sol";
 
 /**
  * @title CarryTokenPresale
  * @dev The Carry token presale contract.
  */
-contract CarryTokenPresale is CarryTokenCrowdsale, GradualDeliveryCrowdsale {
+contract CarryTokenPresale is CarryTokenPresaleBase, GradualDeliveryCrowdsale {
     using SafeMath for uint256;
 
     constructor(
@@ -32,7 +32,7 @@ contract CarryTokenPresale is CarryTokenCrowdsale, GradualDeliveryCrowdsale {
         uint256 _cap,
         uint256 _individualMinPurchaseWei,
         uint256 _individualMaxCapWei
-    ) public CarryTokenCrowdsale(
+    ) public CarryTokenPresaleBase(
         _wallet,
         _token,
         _rate,

--- a/contracts/CarryTokenPresale.sol
+++ b/contracts/CarryTokenPresale.sol
@@ -25,10 +25,7 @@ import "./GradualDeliveryCrowdsale.sol";
 contract CarryTokenPresale is CarryTokenCrowdsale, GradualDeliveryCrowdsale {
     using SafeMath for uint256;
 
-    // FIXME: Here we've wanted to use constructor() keyword instead,
-    // but solium/solhint lint softwares don't parse it properly as of
-    // April 2018.
-    function CarryTokenPresale(
+    constructor(
         address _wallet,
         CarryToken _token,
         uint256 _rate,

--- a/contracts/CarryTokenPresale.sol
+++ b/contracts/CarryTokenPresale.sol
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "./CarryTokenPresaleBase.sol";
 import "./GradualDeliveryCrowdsale.sol";

--- a/contracts/CarryTokenPresaleBase.sol
+++ b/contracts/CarryTokenPresaleBase.sol
@@ -22,11 +22,14 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "./CarryToken.sol";
 
 /**
- * @title CarryTokenCrowdsale
- * @dev The common base contract for both sales: the Carry token presale,
- * and the Carry token public crowdsale.
+ * @title CarryTokenPresaleCrowdsale
+ * @dev The base contract for the Carry token presale.  (Note that it was
+ * intended to be an abstract base contract for common things between
+ * the token presale and the public token crowdsale both, but since
+ * we decided to change the policy for the public crowdsale, so there is no
+ * much common things between both.)
  */
-contract CarryTokenCrowdsale is WhitelistedCrowdsale, CappedCrowdsale, Pausable {
+contract CarryTokenPresaleBase is WhitelistedCrowdsale, CappedCrowdsale, Pausable {
     using SafeMath for uint256;
 
     uint256 constant maxGasPrice = 40000000000;  // 40 gwei

--- a/contracts/CarryTokenPresaleBase.sol
+++ b/contracts/CarryTokenPresaleBase.sol
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 import "openzeppelin-solidity/contracts/crowdsale/validation/CappedCrowdsale.sol";
 import "openzeppelin-solidity/contracts/crowdsale/validation/WhitelistedCrowdsale.sol";
@@ -57,7 +57,10 @@ contract CarryTokenPresaleBase is WhitelistedCrowdsale, CappedCrowdsale, Pausabl
         uint256 _weiAmount
     ) internal whenNotPaused {
         // Prevent gas war among purchasers.
-        require(tx.gasprice <= maxGasPrice);
+        require(
+            tx.gasprice <= maxGasPrice,
+            "Gas price is too expensive. Don't be competitive."
+        );
 
         super._preValidatePurchase(_beneficiary, _weiAmount);
         uint256 contribution = contributions[_beneficiary];
@@ -67,9 +70,15 @@ contract CarryTokenPresaleBase is WhitelistedCrowdsale, CappedCrowdsale, Pausabl
         // then they can purchase once again with less than a minimum amount,
         // say 0.01 ETH, because they have already satisfied the minimum
         // purchase.
-        require(contributionAfterPurchase >= individualMinPurchaseWei);
+        require(
+            contributionAfterPurchase >= individualMinPurchaseWei,
+            "Sent ethers is not enough."
+        );
 
-        require(contributionAfterPurchase <= individualMaxCapWei);
+        require(
+            contributionAfterPurchase <= individualMaxCapWei,
+            "Total ethers you've purchased is too much."
+        );
     }
 
     function _updatePurchasingState(

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-pragma solidity ^0.4.23;
+pragma solidity ^0.4.24;
 
 contract Migrations {
     address public owner;

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -23,10 +23,7 @@ contract Migrations {
         if (msg.sender == owner) _;
     }
 
-    // FIXME: Here we've wanted to use constructor() keyword instead,
-    // but solium/solhint lint softwares don't parse it properly as of
-    // April 2018.
-    function Migrations() public {
+    constructor() public {
         owner = msg.sender;
     }
 

--- a/migrations/3_deploy_public_sale_contracts.js
+++ b/migrations/3_deploy_public_sale_contracts.js
@@ -1,0 +1,92 @@
+// The Carry token and the tokensale contracts
+// Copyright (C) 2018 Carry Protocol
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+const CarryToken = artifacts.require("CarryToken");
+const CarryPublicTokenCrowdsale =
+    artifacts.require("CarryPublicTokenCrowdsale");
+
+const publicSale = {
+    // See also <https://carryprotocol.io/#section-token-distribution>.
+    //   1 ETH = 65,000 CRE
+    //   1 wei = 6.5E-14 CRE
+    // Note that both currencies have the same precision on
+    // their minor units: 18 decimals.
+    rate: 65000,
+
+    // Max cap: 5000.41 ETH = 373,781,000 CRE
+    cap: web3.toWei(5000410, "finney"),
+
+    // Available time frame & individual caps
+    closingTime: +new Date("2018-08-15T20:00:00+09:00"),
+    individualMaxCaps: {
+        [+new Date("2018-08-01T20:00:00+09:00")]: web3.toWei(5, "ether"),
+        [+new Date("2018-08-03T20:00:00+09:00")]: web3.toWei(10, "ether"),
+    },
+    // Due to gas fee, contributors tend to transfer incorrect amount of
+    // ETH which doesn't satisfy the minimum purchase by a whisker,
+    // e.g., 0.0999999... ETH.  In order to prevent such situations
+    // we take 99 finney at least instead of 100 finney sharp.
+    individualMinPurchaseWei: web3.toWei(99, "finney"),
+
+    // The wallet address to receive ethers.  It should be a multisig wallet.
+    wallet: "0x8D5F5f9a2621bE9d32896CF0172515Fb211E26bE",
+};
+
+module.exports = (deployer, network, accounts) => {
+    let delay = 0;
+    if ((process.env.DELAY_SECONDS || "").match(/^\d+$/)) {
+        delay = process.env.DELAY_SECONDS * 1000;
+    }
+    const tokenOwner =
+        process.env.TOKEN_OWNER
+            ? process.env.TOKEN_OWNER.toLowerCase()
+            : accounts[0];
+    if (!accounts.includes(tokenOwner)) {
+        throw new Error(
+            "No private key is available for the account " + tokenOwner +
+            "; available accounts are: " + accounts.join(", ")
+        );
+    }
+    let carryToken;
+    CarryToken.deployed().then(() => {
+        return CarryToken.deployed();
+    }).then((_carryToken) => {
+        carryToken = _carryToken;
+        return deployer.deploy(
+            CarryPublicTokenCrowdsale,
+            publicSale.wallet,
+            carryToken.address,
+            publicSale.rate,
+            publicSale.cap,
+            publicSale.closingTime,
+            publicSale.individualMinPurchaseWei,
+            Object.entries(publicSale.individualMaxCaps).reduce(
+                (a, b) => a.concat(b)
+            )
+        );
+    }).then(c => {
+        return new Promise(resolve => setTimeout(() => resolve(c), delay));
+    }).then(() => {
+        return CarryPublicTokenCrowdsale.deployed();
+    }).then((carryPublicTokenCrowdsale) => {
+        return carryToken.mint(
+            carryPublicTokenCrowdsale.address,
+            new web3.BigNumber(publicSale.cap).mul(publicSale.rate),
+            {from: tokenOwner}
+        );
+    }).then(c => {
+        return new Promise(resolve => setTimeout(() => resolve(c), delay));
+    });
+};

--- a/migrations/3_deploy_public_sale_contracts.js
+++ b/migrations/3_deploy_public_sale_contracts.js
@@ -17,6 +17,10 @@ const CarryToken = artifacts.require("CarryToken");
 const CarryPublicTokenCrowdsale =
     artifacts.require("CarryPublicTokenCrowdsale");
 
+function timestamp(iso8601) {
+    return +new Date(iso8601) / 1000 >> 0;
+}
+
 const publicSale = {
     // See also <https://carryprotocol.io/#section-token-distribution>.
     //   1 ETH = 65,000 CRE
@@ -29,10 +33,10 @@ const publicSale = {
     cap: web3.toWei(5000410, "finney"),
 
     // Available time frame & individual caps
-    closingTime: +new Date("2018-08-15T20:00:00+09:00"),
+    closingTime: timestamp("2018-08-15T20:00:00+09:00"),
     individualMaxCaps: {
-        [+new Date("2018-08-01T20:00:00+09:00")]: web3.toWei(5, "ether"),
-        [+new Date("2018-08-03T20:00:00+09:00")]: web3.toWei(10, "ether"),
+        [timestamp("2018-08-01T20:00:00+09:00")]: web3.toWei(5, "ether"),
+        [timestamp("2018-08-03T20:00:00+09:00")]: web3.toWei(10, "ether"),
     },
     // Due to gas fee, contributors tend to transfer incorrect amount of
     // ETH which doesn't satisfy the minimum purchase by a whisker,

--- a/migrations/3_deploy_public_sale_contracts.js
+++ b/migrations/3_deploy_public_sale_contracts.js
@@ -33,10 +33,10 @@ const publicSale = {
     cap: web3.toWei(5000410, "finney"),
 
     // Available time frame & individual caps
-    closingTime: timestamp("2018-08-15T20:00:00+09:00"),
     individualMaxCaps: {
         [timestamp("2018-08-01T20:00:00+09:00")]: web3.toWei(5, "ether"),
         [timestamp("2018-08-03T20:00:00+09:00")]: web3.toWei(10, "ether"),
+        [timestamp("2018-08-15T20:00:00+09:00")]: 0,  // closing time
     },
     // Due to gas fee, contributors tend to transfer incorrect amount of
     // ETH which doesn't satisfy the minimum purchase by a whisker,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1590,7 +1590,7 @@
       "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "requires": {
-        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#4ea2fdfed09e8f99117d9362d17c6b01b64a2bcf",
+        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
         "ethereumjs-util": "5.2.0"
       },
       "dependencies": {
@@ -1616,7 +1616,7 @@
       "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
     },
     "ethereumjs-abi": {
-      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#4ea2fdfed09e8f99117d9362d17c6b01b64a2bcf",
+      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
       "requires": {
         "bn.js": "4.11.8",
         "ethereumjs-util": "5.2.0"
@@ -1996,21 +1996,25 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "optional": true,
           "requires": {
             "delegates": "1.0.0",
@@ -2019,11 +2023,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "requires": {
             "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
@@ -2031,29 +2037,35 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "optional": true,
           "requires": {
             "ms": "2.0.0"
@@ -2061,22 +2073,26 @@
         },
         "deep-extend": {
           "version": "0.4.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "optional": true,
           "requires": {
             "minipass": "2.2.4"
@@ -2084,12 +2100,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "optional": true,
           "requires": {
             "aproba": "1.2.0",
@@ -2104,7 +2122,8 @@
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "optional": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -2117,12 +2136,14 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+          "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
           "optional": true,
           "requires": {
             "safer-buffer": "2.1.2"
@@ -2130,7 +2151,8 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "optional": true,
           "requires": {
             "minimatch": "3.0.4"
@@ -2138,7 +2160,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "optional": true,
           "requires": {
             "once": "1.4.0",
@@ -2147,39 +2170,46 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
             "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
             "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "minipass": {
           "version": "2.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
+          "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "requires": {
             "safe-buffer": "5.1.1",
             "yallist": "3.0.2"
@@ -2187,7 +2217,8 @@
         },
         "minizlib": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+          "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
           "optional": true,
           "requires": {
             "minipass": "2.2.4"
@@ -2195,19 +2226,22 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
+          "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
           "optional": true,
           "requires": {
             "debug": "2.6.9",
@@ -2217,7 +2251,8 @@
         },
         "node-pre-gyp": {
           "version": "0.9.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.9.1.tgz",
+          "integrity": "sha1-8RwHUW3ZL4cZnbx+GDjqt81WyeA=",
           "optional": true,
           "requires": {
             "detect-libc": "1.0.3",
@@ -2234,7 +2269,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "optional": true,
           "requires": {
             "abbrev": "1.1.1",
@@ -2243,12 +2279,14 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
+          "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
+          "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
           "optional": true,
           "requires": {
             "ignore-walk": "3.0.1",
@@ -2257,7 +2295,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "optional": true,
           "requires": {
             "are-we-there-yet": "1.1.4",
@@ -2268,33 +2307,39 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
             "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "optional": true,
           "requires": {
             "os-homedir": "1.0.2",
@@ -2303,17 +2348,20 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "optional": true
         },
         "rc": {
           "version": "1.2.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
+          "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
           "optional": true,
           "requires": {
             "deep-extend": "0.4.2",
@@ -2324,14 +2372,16 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "optional": true
             }
           }
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "optional": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -2345,7 +2395,8 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "optional": true,
           "requires": {
             "glob": "7.1.2"
@@ -2353,36 +2404,43 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "optional": true
         },
         "semver": {
           "version": "5.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
@@ -2391,7 +2449,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "optional": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -2399,19 +2458,22 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "optional": true
         },
         "tar": {
           "version": "4.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
+          "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
           "optional": true,
           "requires": {
             "chownr": "1.0.1",
@@ -2425,12 +2487,14 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "optional": true,
           "requires": {
             "string-width": "1.0.2"
@@ -2438,11 +2502,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1006,7 +1006,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
-        "fsevents": "1.2.3",
+        "fsevents": "1.2.4",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -1097,9 +1097,9 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colors": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.1.tgz",
-      "integrity": "sha512-s8+wktIuDSLffCywiwSxQOMqtPxML11a/dtHE17tMn4B1MSWw/C22EKf7M2KGUBcDaVFEGT+S8N02geDXeuNKg=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.0.tgz",
+      "integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw=="
     },
     "combined-stream": {
       "version": "1.0.6",
@@ -1110,12 +1110,9 @@
       }
     },
     "commander": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "requires": {
-        "graceful-readlink": "1.0.1"
-      }
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
+      "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1302,6 +1299,11 @@
         "repeating": "2.0.1"
       }
     },
+    "diff": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
+    },
     "doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -1360,6 +1362,11 @@
       "requires": {
         "iconv-lite": "0.4.21"
       }
+    },
+    "eol": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/eol/-/eol-0.9.1.tgz",
+      "integrity": "sha512-Ds/TEoZjwggRoz/Q2O7SE3i4Jm66mqTDfmdHdq/7DKVk3bro9Q8h6WdXKdPqFLMoqxrDK5SVRzHVPOS6uuGtrg=="
     },
     "errno": {
       "version": "0.1.7",
@@ -1810,7 +1817,7 @@
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "2.2.4"
       }
     },
     "extend": {
@@ -1895,13 +1902,13 @@
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
     },
     "fill-range": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
       "requires": {
         "is-number": "2.1.0",
         "isobject": "2.1.0",
-        "randomatic": "1.1.7",
+        "randomatic": "3.0.0",
         "repeat-element": "1.1.2",
         "repeat-string": "1.6.1"
       }
@@ -1985,36 +1992,32 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.3.tgz",
-      "integrity": "sha512-X+57O5YkDTiEQGiw8i7wYc2nQgweIekqkepI8Q3y4wVlurgBt2SuwxTeYUYMZIGpLZH3r/TsMjczCMXE5ZOt7Q==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
       "optional": true,
       "requires": {
         "nan": "2.10.0",
-        "node-pre-gyp": "0.9.1"
+        "node-pre-gyp": "0.10.0"
       },
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+          "bundled": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+          "bundled": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "delegates": "1.0.0",
@@ -2023,13 +2026,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "bundled": true,
           "requires": {
             "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
@@ -2037,62 +2038,52 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+          "bundled": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "bundled": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
         "deep-extend": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+          "version": "0.5.1",
+          "bundled": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+          "bundled": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+          "bundled": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "minipass": "2.2.4"
@@ -2100,14 +2091,12 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "bundled": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "aproba": "1.2.0",
@@ -2122,8 +2111,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -2136,14 +2124,12 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+          "bundled": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
-          "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "safer-buffer": "2.1.2"
@@ -2151,8 +2137,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "minimatch": "3.0.4"
@@ -2160,8 +2145,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "once": "1.4.0",
@@ -2170,46 +2154,39 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+          "bundled": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "bundled": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "bundled": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "bundled": true,
           "requires": {
             "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
-          "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+          "bundled": true,
           "requires": {
             "safe-buffer": "5.1.1",
             "yallist": "3.0.2"
@@ -2217,8 +2194,7 @@
         },
         "minizlib": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
-          "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "minipass": "2.2.4"
@@ -2226,22 +2202,19 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "bundled": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
-          "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "debug": "2.6.9",
@@ -2250,9 +2223,8 @@
           }
         },
         "node-pre-gyp": {
-          "version": "0.9.1",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.9.1.tgz",
-          "integrity": "sha1-8RwHUW3ZL4cZnbx+GDjqt81WyeA=",
+          "version": "0.10.0",
+          "bundled": true,
           "optional": true,
           "requires": {
             "detect-libc": "1.0.3",
@@ -2261,7 +2233,7 @@
             "nopt": "4.0.1",
             "npm-packlist": "1.1.10",
             "npmlog": "4.1.2",
-            "rc": "1.2.6",
+            "rc": "1.2.7",
             "rimraf": "2.6.2",
             "semver": "5.5.0",
             "tar": "4.4.1"
@@ -2269,8 +2241,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "bundled": true,
           "optional": true,
           "requires": {
             "abbrev": "1.1.1",
@@ -2279,14 +2250,12 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
-          "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
+          "bundled": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
-          "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "ignore-walk": "3.0.1",
@@ -2295,8 +2264,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "are-we-there-yet": "1.1.4",
@@ -2307,39 +2275,33 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "bundled": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "requires": {
             "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "bundled": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+          "bundled": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "os-homedir": "1.0.2",
@@ -2348,23 +2310,20 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "bundled": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+          "bundled": true,
           "optional": true
         },
         "rc": {
-          "version": "1.2.6",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
-          "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
+          "version": "1.2.7",
+          "bundled": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.4.2",
+            "deep-extend": "0.5.1",
             "ini": "1.3.5",
             "minimist": "1.2.0",
             "strip-json-comments": "2.0.1"
@@ -2372,16 +2331,14 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "bundled": true,
               "optional": true
             }
           }
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -2395,8 +2352,7 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "glob": "7.1.2"
@@ -2404,43 +2360,36 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+          "bundled": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+          "bundled": true,
           "optional": true
         },
         "semver": {
           "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "bundled": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "bundled": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "bundled": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "bundled": true,
           "requires": {
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
@@ -2449,8 +2398,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -2458,22 +2406,19 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "bundled": true,
           "requires": {
             "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "bundled": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
-          "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "chownr": "1.0.1",
@@ -2487,14 +2432,12 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+          "bundled": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+          "bundled": true,
           "optional": true,
           "requires": {
             "string-width": "1.0.2"
@@ -2502,13 +2445,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+          "bundled": true
         }
       }
     },
@@ -2602,10 +2543,10 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
     },
     "har-schema": {
       "version": "2.0.0",
@@ -2636,6 +2577,11 @@
       "requires": {
         "ansi-regex": "2.1.1"
       }
+    },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
     },
     "hash-base": {
       "version": "3.0.4",
@@ -3365,6 +3311,11 @@
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
       "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
     },
+    "math-random": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
+    },
     "md5.js": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
@@ -3523,6 +3474,51 @@
         "minimist": "0.0.8"
       }
     },
+    "mocha": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -3630,9 +3626,9 @@
       }
     },
     "openzeppelin-solidity": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.9.0.tgz",
-      "integrity": "sha512-MGI8clDbjrfWUg90AM82O+CHOaabtE2u9HyaUhBMKfWdIaO1urRUIgXIrEuloLvFEBHb5rtcgTARb5DkhUB4KQ=="
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-1.11.0.tgz",
+      "integrity": "sha512-s4hFpQ9nMvFQBUuY0OJ7PfvSEprPcUph/YGvlgqJYQc6rNjsreRSj9Iq6ftTFI2anlECvWg/wWnNdPq4Tih1FA=="
     },
     "optionator": {
       "version": "0.8.2",
@@ -3676,9 +3672,9 @@
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
-      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "requires": {
         "p-try": "1.0.0"
       }
@@ -3688,7 +3684,7 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "requires": {
-        "p-limit": "1.2.0"
+        "p-limit": "1.3.0"
       }
     },
     "p-try": {
@@ -3867,39 +3863,24 @@
       "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
     "randomatic": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
+      "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "4.0.0",
+        "kind-of": "6.0.2",
+        "math-random": "1.0.1"
       },
       "dependencies": {
         "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
         },
         "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
@@ -4328,14 +4309,15 @@
       }
     },
     "solium": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/solium/-/solium-1.1.7.tgz",
-      "integrity": "sha512-yYbalsrzJCU+QJ0HZvxAT4IQIqI1e6KPW2vop0NaHwdijqhQC9fJkVioCrL18NbO2Z8rdcnx8Y0JpvYJWrIjRg==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/solium/-/solium-1.1.8.tgz",
+      "integrity": "sha512-fn0lusM6of14CytIDDHK73SGjn6NsVTaCVJjaKCKJyqKhT00rH/hDtvnIeZ2ZTD9z/xaXd4Js2brW3az6AV9RA==",
       "requires": {
         "ajv": "5.5.2",
         "chokidar": "1.7.0",
-        "colors": "1.2.1",
-        "commander": "2.9.0",
+        "colors": "1.3.0",
+        "commander": "2.16.0",
+        "eol": "0.9.1",
         "js-string-escape": "1.0.1",
         "lodash": "4.17.10",
         "sol-digger": "0.0.2",
@@ -4343,6 +4325,21 @@
         "solium-plugin-security": "0.1.1",
         "solparse": "2.2.5",
         "text-table": "0.2.0"
+      }
+    },
+    "solium-plugin-security": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/solium-plugin-security/-/solium-plugin-security-0.1.1.tgz",
+      "integrity": "sha512-kpLirBwIq4mhxk0Y/nn5cQ6qdJTI+U1LO3gpoNIcqNaW+sI058moXBe2UiHs+9wvF9IzYD49jcKhFTxcR9u9SQ=="
+    },
+    "solparse": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/solparse/-/solparse-2.2.5.tgz",
+      "integrity": "sha512-t7tvtR6KU6QfPYLMv1nlCh9DA8HYIu5tbjHpKu0fhGFZ1NuSp0KKDHfFHv07g6v1xgcuUY3rVqNFjZt5b9+5qA==",
+      "requires": {
+        "mocha": "4.1.0",
+        "pegjs": "0.10.0",
+        "yargs": "10.1.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -4365,19 +4362,6 @@
             "wrap-ansi": "2.1.0"
           }
         },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "diff": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-          "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
-        },
         "find-up": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -4386,57 +4370,10 @@
             "locate-path": "2.0.0"
           }
         },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "growl": {
-          "version": "1.10.3",
-          "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-          "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
-        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-        },
-        "mocha": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
-          "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
-          "requires": {
-            "browser-stdout": "1.3.0",
-            "commander": "2.11.0",
-            "debug": "3.1.0",
-            "diff": "3.3.1",
-            "escape-string-regexp": "1.0.5",
-            "glob": "7.1.2",
-            "growl": "1.10.3",
-            "he": "1.1.1",
-            "mkdirp": "0.5.1",
-            "supports-color": "4.4.0"
-          },
-          "dependencies": {
-            "commander": {
-              "version": "2.11.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-              "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
-            }
-          }
         },
         "os-locale": {
           "version": "2.1.0",
@@ -4446,16 +4383,6 @@
             "execa": "0.7.0",
             "lcid": "1.0.0",
             "mem": "1.1.0"
-          }
-        },
-        "solparse": {
-          "version": "2.2.5",
-          "resolved": "https://registry.npmjs.org/solparse/-/solparse-2.2.5.tgz",
-          "integrity": "sha512-t7tvtR6KU6QfPYLMv1nlCh9DA8HYIu5tbjHpKu0fhGFZ1NuSp0KKDHfFHv07g6v1xgcuUY3rVqNFjZt5b9+5qA==",
-          "requires": {
-            "mocha": "4.1.0",
-            "pegjs": "0.10.0",
-            "yargs": "10.1.2"
           }
         },
         "string-width": {
@@ -4473,14 +4400,6 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
             "ansi-regex": "3.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "requires": {
-            "has-flag": "2.0.0"
           }
         },
         "which-module": {
@@ -4516,11 +4435,6 @@
           }
         }
       }
-    },
-    "solium-plugin-security": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/solium-plugin-security/-/solium-plugin-security-0.1.1.tgz",
-      "integrity": "sha512-kpLirBwIq4mhxk0Y/nn5cQ6qdJTI+U1LO3gpoNIcqNaW+sI058moXBe2UiHs+9wvF9IzYD49jcKhFTxcR9u9SQ=="
     },
     "source-map": {
       "version": "0.5.7",
@@ -4650,6 +4564,14 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
+    "supports-color": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "requires": {
+        "has-flag": "2.0.0"
+      }
+    },
     "table": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
@@ -4774,73 +4696,15 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "truffle": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/truffle/-/truffle-4.1.11.tgz",
-      "integrity": "sha512-VNhc6jexZeM92sNJJr4U8ln3uJ/mJEQO/0y9ZLYc4pccyIskPtl+3r4mzymgGM/Mq5v6MpoQVD6NZgHUVKX+Dw==",
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/truffle/-/truffle-4.1.13.tgz",
+      "integrity": "sha1-vydYaYi0/4RWPt+/MrR5QUCKdq0=",
       "requires": {
         "mocha": "4.1.0",
         "original-require": "1.0.1",
         "solc": "0.4.24"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "diff": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-          "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "growl": {
-          "version": "1.10.3",
-          "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-          "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
-        },
-        "mocha": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
-          "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
-          "requires": {
-            "browser-stdout": "1.3.0",
-            "commander": "2.11.0",
-            "debug": "3.1.0",
-            "diff": "3.3.1",
-            "escape-string-regexp": "1.0.5",
-            "glob": "7.1.2",
-            "growl": "1.10.3",
-            "he": "1.1.1",
-            "mkdirp": "0.5.1",
-            "supports-color": "4.4.0"
-          }
-        },
         "solc": {
           "version": "0.4.24",
           "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.24.tgz",
@@ -4851,14 +4715,6 @@
             "require-from-string": "1.2.1",
             "semver": "5.5.0",
             "yargs": "4.8.1"
-          }
-        },
-        "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "requires": {
-            "has-flag": "2.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "deasync": "^0.1.12",
     "eslint": "^4.19.1",
     "openzeppelin-solidity": "1.9.0",
-    "solium": "^1.1.6",
+    "solium": "^1.1.7",
     "truffle": "^4.1.7",
     "truffle-hdwallet-provider": "0.0.3",
     "truffle-hdwallet-provider-privkey": "https://github.com/rhlsthrm/truffle-hdwallet-provider-privkey/archive/c226346761ea0dac05d59824cb0a6bd785022e55.tar.gz"

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   "dependencies": {
     "deasync": "^0.1.12",
     "eslint": "^4.19.1",
-    "openzeppelin-solidity": "1.9.0",
-    "solium": "^1.1.7",
-    "truffle": "^4.1.7",
+    "openzeppelin-solidity": "^1.11.0",
+    "solium": "^1.1.8",
+    "truffle": "^4.1.13",
     "truffle-hdwallet-provider": "0.0.3",
     "truffle-hdwallet-provider-privkey": "https://github.com/rhlsthrm/truffle-hdwallet-provider-privkey/archive/c226346761ea0dac05d59824cb0a6bd785022e55.tar.gz"
   },

--- a/scripts/whitelist.js
+++ b/scripts/whitelist.js
@@ -112,7 +112,7 @@ async function updateWhitelist(
         console.info("The first address of this chunk: " + addresses[0]);
         console.info("Gas limit: " + gasLimit);
         try {
-            await contract.addManyToWhitelist(addresses, {
+            await contract.addAddressesToWhitelist(addresses, {
                 gas: gasLimit,
                 gasPrice: web3.toWei(gasPriceGwei, "gwei"),
             });
@@ -129,7 +129,7 @@ async function updateWhitelist(
                     console.info("Failed due to nonce mismatch; retry...");
                 }
                 try {
-                    await contract.addManyToWhitelist(addresses, {
+                    await contract.addAddressesToWhitelist(addresses, {
                         gas: gasLimit,
                         gasPrice: web3.toWei(gasPriceGwei * multiply, "gwei"),
                     });

--- a/test/SampleGradualDeliveryCrowdsale.sol
+++ b/test/SampleGradualDeliveryCrowdsale.sol
@@ -23,10 +23,7 @@ import "../contracts/GradualDeliveryCrowdsale.sol";
 // constructor, we need to define a concrete class inheriting it and having
 // its own constructor.
 contract SampleGradualDeliveryCrowdsale is GradualDeliveryCrowdsale {
-    // FIXME: Here we've wanted to use constructor() keyword instead,
-    // but solium/solhint lint softwares don't parse it properly as of
-    // April 2018.
-    function SampleGradualDeliveryCrowdsale(
+    constructor(
         uint256 _rate,
         address _wallet,
         ERC20 _token

--- a/test/carryPublicTokenCrowdsale.js
+++ b/test/carryPublicTokenCrowdsale.js
@@ -1,0 +1,209 @@
+// The Carry token and the tokensale contracts
+// Copyright (C) 2018 Carry Protocol
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+const { assertFail, multipleContracts } = require("./utils");
+
+const currentTimestamp = +new Date() / 1000 >> 0;
+const minute = 60;
+const hour = 60 * minute;
+const day = 24 * hour;
+
+multipleContracts({
+    "CarryPublicTokenCrowdsale (not opened yet)": (fundWallet, token) => [
+        // Use similar arguments to the publicSale (though not necessarily).
+        // See also presale constant on
+        // migrations/3_deploy_public_sale_contracts.js file.
+        fundWallet,  // wallet
+        token.address,  // token contract
+        65000,  // rate
+        web3.toWei(5000410, "finney"),  // cap
+        currentTimestamp + 31 * day,  // closingTime: a month later
+        web3.toWei(99, "finney"),  // individualMinPurchaseWei
+        [
+            currentTimestamp + 14 * day,  // 2 weeks later
+            web3.toWei(5, "ether"),
+            currentTimestamp + 21 * day,  // 3 weeks later
+            web3.toWei(10, "ether"),
+        ],
+    ],
+    "CarryPublicTokenCrowdsale (opened; phase 1)": (fundWallet, token) => [
+        // Use similar arguments to the publicSale (though not necessarily).
+        // See also presale constant on
+        // migrations/3_deploy_public_sale_contracts.js file.
+        fundWallet,  // wallet
+        token.address,  // token contract
+        65000,  // rate
+        web3.toWei(5000410, "finney"),  // cap
+        14 * day + currentTimestamp,  // closingTime: 2 weeks later
+        web3.toWei(99, "finney"),  // individualMinPurchaseWei
+        [
+            currentTimestamp - 7 * day,  // a week ago
+            web3.toWei(5, "ether"),
+            currentTimestamp + 7 * day,  // a week later
+            web3.toWei(10, "ether"),
+        ],
+    ],
+    "CarryPublicTokenCrowdsale (opened; phase 2)": (fundWallet, token) => [
+        // Use similar arguments to the publicSale (though not necessarily).
+        // See also presale constant on
+        // migrations/3_deploy_public_sale_contracts.js file.
+        fundWallet,  // wallet
+        token.address,  // token contract
+        65000,  // rate
+        web3.toWei(5000410, "finney"),  // cap
+        14 * day + currentTimestamp,  // closingTime: 2 weeks later
+        web3.toWei(99, "finney"),  // individualMinPurchaseWei
+        [
+            currentTimestamp - 14 * day,  // 2 weeks ago
+            web3.toWei(5, "ether"),
+            currentTimestamp - 7 * day,  // a week ago
+            web3.toWei(10, "ether"),
+        ],
+    ],
+    "CarryPublicTokenCrowdsale (already closed)": (fundWallet, token) => [
+        // Use similar arguments to the publicSale (though not necessarily).
+        // See also presale constant on
+        // migrations/3_deploy_public_sale_contracts.js file.
+        fundWallet,  // wallet
+        token.address,  // token contract
+        65000,  // rate
+        web3.toWei(5000410, "finney"),  // cap
+        currentTimestamp - 7 * day,  // closingTime: a week ago
+        web3.toWei(99, "finney"),  // individualMinPurchaseWei
+        [
+            currentTimestamp - 31 * day,  // a month ago
+            web3.toWei(5, "ether"),
+            currentTimestamp - 14 * day,  // 2 weeks ago
+            web3.toWei(10, "ether"),
+        ],
+    ],
+}, ({ testName, getAccount, fundOwner, getFund, withoutBalanceChangeIt  }) => {
+    const phase1 = testName.indexOf("(opened; phase 1)") >= 0;
+    const phase2 = testName.indexOf("(opened; phase 2)") >= 0;
+    const opened = phase1 || phase2;
+
+    if (!opened) {
+        it(
+            "should not receive ethers if it's not opened yet or already closed",
+            async () => {
+                const contributor = getAccount();
+                const fund = getFund();
+                // TODO: We may need to add contributor to whitelist here
+                await assertFail(
+                    fund.sendTransaction({
+                        value: web3.toWei(5, "finney"),
+                        from: contributor,
+                    })
+                );
+            }
+        );
+    }
+
+    withoutBalanceChangeIt(
+        "should not receive less than individualMinPurchaseWei",
+        async () => {
+            // TODO: We may need to add contributor to whitelist here
+            return await getFund().individualMinPurchaseWei();
+        },
+        async (contributor, individualMinPurchaseWei) => {
+            await assertFail(
+                getFund().sendTransaction({
+                    value: individualMinPurchaseWei.minus(1),
+                    from: contributor,
+                }),
+                "Transfer should be failed"
+            );
+        }
+    );
+
+    if (opened) {
+        const individualMaxCapWei =
+            new web3.BigNumber(web3.toWei(phase1 ? 5 : 10, "ether"));
+
+        withoutBalanceChangeIt(
+            "should not receive more than individual max cap per contributor",
+            async () => {
+                // TODO: We may need to add contributor to whitelist here
+            },
+            async (contributor) => {
+                await assertFail(
+                    getFund().sendTransaction({
+                        value: individualMaxCapWei.plus(1),
+                        from: contributor,
+                    }),
+                    "Transfer should be failed"
+                );
+            }
+        );
+
+        withoutBalanceChangeIt(
+            "should not receive more than total individual max cap " +
+            "per contributor",
+            async (contributor) => {
+                const fund = getFund();
+                // TODO: We may need to add contributor to whitelist here
+                const amount = web3.toWei(1, "ether");
+                await fund.sendTransaction({
+                    value: amount,
+                    from: contributor,
+                });
+                return individualMaxCapWei.minus(amount);
+            },
+            async (contributor, remainingAllowedPurchase) => {
+                await assertFail(
+                    getFund().sendTransaction({
+                        value: remainingAllowedPurchase.plus(1),
+                        from: contributor,
+                    }),
+                    "Transfer should be failed"
+                );
+            }
+        );
+
+        it("should receive if all conditions are satisfied", async () => {
+            const contributor = getAccount();
+            const fund = getFund();
+            // TODO: We may need to add contributor to whitelist here
+            await fund.sendTransaction({
+                value: web3.toWei(100, "finney"),
+                from: contributor,
+            });
+            await fund.sendTransaction({
+                value: individualMaxCapWei.minus(web3.toWei(100, "finney")),
+                from: contributor,
+            });
+        });
+    }
+
+    it("should not receive ethers if it is paused", async () => {
+        const contributor = getAccount();
+        const fund = getFund();
+        // TODO: We may need to add contributor to whitelist here
+        await fund.pause({from: fundOwner});
+        await assertFail(
+            fund.sendTransaction({
+                value: web3.toWei(100, "finney"),
+                from: contributor,
+            })
+        );
+        if (opened) {
+            await fund.unpause({from: fundOwner});
+            await fund.sendTransaction({
+                value: web3.toWei(100, "finney"),
+                from: contributor,
+            });
+        }
+    });
+});

--- a/test/carryPublicTokenCrowdsale.js
+++ b/test/carryPublicTokenCrowdsale.js
@@ -206,4 +206,19 @@ multipleContracts({
             });
         }
     });
+
+    it("rejects TXes paying more than 40 gwei for gas price", async () => {
+        const maxGasPrice = new web3.BigNumber(web3.toWei(40, "gwei"));
+        const contributor = getAccount();
+        const fund = getFund();
+        // TODO: We may need to add contributor to whitelist here
+        await assertFail(
+            fund.sendTransaction({
+                value: web3.toWei(100, "finney"),
+                from: contributor,
+                gasPrice: maxGasPrice.plus(1),
+            }),
+            "The TX paying more than 40 gwei for gas price should fail."
+        );
+    });
 });

--- a/test/carryPublicTokenCrowdsale.js
+++ b/test/carryPublicTokenCrowdsale.js
@@ -29,13 +29,14 @@ multipleContracts({
         token.address,  // token contract
         65000,  // rate
         web3.toWei(5000410, "finney"),  // cap
-        currentTimestamp + 31 * day,  // closingTime: a month later
         web3.toWei(99, "finney"),  // individualMinPurchaseWei
         [
             currentTimestamp + 14 * day,  // 2 weeks later
             web3.toWei(5, "ether"),
             currentTimestamp + 21 * day,  // 3 weeks later
             web3.toWei(10, "ether"),
+            currentTimestamp + 31 * day,  // closingTime: a month later
+            0,
         ],
     ],
     "CarryPublicTokenCrowdsale (opened; phase 1)": (fundWallet, token) => [
@@ -46,13 +47,14 @@ multipleContracts({
         token.address,  // token contract
         65000,  // rate
         web3.toWei(5000410, "finney"),  // cap
-        14 * day + currentTimestamp,  // closingTime: 2 weeks later
         web3.toWei(99, "finney"),  // individualMinPurchaseWei
         [
             currentTimestamp - 7 * day,  // a week ago
             web3.toWei(5, "ether"),
             currentTimestamp + 7 * day,  // a week later
             web3.toWei(10, "ether"),
+            currentTimestamp + 14 * day,  // closingTime: 2 weeks later
+            0,
         ],
     ],
     "CarryPublicTokenCrowdsale (opened; phase 2)": (fundWallet, token) => [
@@ -63,13 +65,14 @@ multipleContracts({
         token.address,  // token contract
         65000,  // rate
         web3.toWei(5000410, "finney"),  // cap
-        14 * day + currentTimestamp,  // closingTime: 2 weeks later
         web3.toWei(99, "finney"),  // individualMinPurchaseWei
         [
             currentTimestamp - 14 * day,  // 2 weeks ago
             web3.toWei(5, "ether"),
             currentTimestamp - 7 * day,  // a week ago
             web3.toWei(10, "ether"),
+            currentTimestamp + 14 * day,  // closingTime: 2 weeks later
+            0,
         ],
     ],
     "CarryPublicTokenCrowdsale (already closed)": (fundWallet, token) => [
@@ -80,13 +83,14 @@ multipleContracts({
         token.address,  // token contract
         65000,  // rate
         web3.toWei(5000410, "finney"),  // cap
-        currentTimestamp - 7 * day,  // closingTime: a week ago
         web3.toWei(99, "finney"),  // individualMinPurchaseWei
         [
             currentTimestamp - 31 * day,  // a month ago
             web3.toWei(5, "ether"),
             currentTimestamp - 14 * day,  // 2 weeks ago
             web3.toWei(10, "ether"),
+            currentTimestamp - 7 * day,  // closingTime: a week ago
+            0,
         ],
     ],
 }, ({ testName, getAccount, fundOwner, getFund, withoutBalanceChangeIt  }) => {

--- a/test/carryPublicTokenCrowdsale.js
+++ b/test/carryPublicTokenCrowdsale.js
@@ -107,7 +107,7 @@ multipleContracts({
                 // TODO: We may need to add contributor to whitelist here
                 await assertFail(
                     fund.sendTransaction({
-                        value: web3.toWei(5, "finney"),
+                        value: web3.toWei(100, "finney"),
                         from: contributor,
                     })
                 );

--- a/test/carryTokenPresaleBase.js
+++ b/test/carryTokenPresaleBase.js
@@ -84,7 +84,9 @@ multipleContracts(
         withoutBalanceChangeIt(
             "should not receive less than individualMinPurchaseWei",
             async (contributor) => {
-                await getFund().addToWhitelist(contributor, {from: fundOwner});
+                await getFund().addAddressToWhitelist(contributor, {
+                    from: fundOwner,
+                });
                 return await getFund().individualMinPurchaseWei();
             },
             async (contributor, individualMinPurchaseWei) => {
@@ -101,7 +103,9 @@ multipleContracts(
         withoutBalanceChangeIt(
             "should not receive more than individualMaxCapWei per contributor",
             async (contributor) => {
-                await getFund().addToWhitelist(contributor, {from: fundOwner});
+                await getFund().addAddressToWhitelist(contributor, {
+                    from: fundOwner,
+                });
                 return await getFund().individualMaxCapWei();
             },
             async (contributor, individualMaxCapWei) => {
@@ -120,7 +124,9 @@ multipleContracts(
             "per contributor",
             async (contributor) => {
                 const fund = getFund();
-                await fund.addToWhitelist(contributor, {from: fundOwner});
+                await fund.addAddressToWhitelist(contributor, {
+                    from: fundOwner,
+                });
                 const amount = web3.toWei(1, "ether");
                 await fund.sendTransaction({
                     value: amount,
@@ -143,7 +149,7 @@ multipleContracts(
         it("should receive if all conditions are satisfied", async () => {
             const contributor = getAccount();
             const fund = getFund();
-            await fund.addToWhitelist(contributor, {from: fundOwner});
+            await fund.addAddressToWhitelist(contributor, {from: fundOwner});
             await fund.sendTransaction({
                 value: web3.toWei(100, "finney"),
                 from: contributor,
@@ -153,7 +159,7 @@ multipleContracts(
         it("should not receive ethers if it is paused", async () => {
             const contributor = getAccount();
             const fund = getFund();
-            await fund.addToWhitelist(contributor, {from: fundOwner});
+            await fund.addAddressToWhitelist(contributor, {from: fundOwner});
             await fund.pause({from: fundOwner});
             await assertFail(
                 fund.sendTransaction({
@@ -172,7 +178,7 @@ multipleContracts(
             const maxGasPrice = new web3.BigNumber(web3.toWei(40, "gwei"));
             const contributor = getAccount();
             const fund = getFund();
-            await fund.addToWhitelist(contributor, {from: fundOwner});
+            await fund.addAddressToWhitelist(contributor, {from: fundOwner});
             await assertFail(
                 fund.sendTransaction({
                     value: web3.toWei(100, "finney"),

--- a/test/carryTokenPresaleBase.js
+++ b/test/carryTokenPresaleBase.js
@@ -17,7 +17,7 @@ const { assertEq, assertFail, multipleContracts } = require("./utils");
 
 multipleContracts(
     {
-        "CarryTokenCrowdsale": (fundWallet, token) => [
+        "CarryTokenPresaleBase": (fundWallet, token) => [
             // Use the same arguments to the presale (though not necessarily).
             // See also presale constant on migrations/2_deploy_contracts.js
             // file.

--- a/test/carryTokenPresaleBase.js
+++ b/test/carryTokenPresaleBase.js
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-const { assertEq, assertFail, multipleContracts } = require("./utils");
+const { assertFail, multipleContracts } = require("./utils");
 
 multipleContracts(
     {
@@ -40,34 +40,7 @@ multipleContracts(
             web3.toWei(50, "ether"),  // individualMaxCapWei
         ],
     },
-    async function ({ getAccount, fundWallet, fundOwner, getFund }) {
-        function withoutBalanceChangeIt (label, fA, fB) {
-            it(label, async () => {
-                const pre = fB ? fA : async () => null;
-                const test = fB ? fB : fA;
-                const contributor = getAccount();
-
-                // pre() runs before "previous" balances are captured.
-                const state = await pre(contributor);
-
-                const prevContributorBalance = web3.eth.getBalance(contributor);
-                const prevFundWalletBalance = web3.eth.getBalance(fundWallet);
-                await test(contributor, state);
-                assert(
-                    prevContributorBalance.sub(
-                        web3.eth.getBalance(contributor)
-                    ).lt(web3.toWei(5, "finney")),
-                    "Amount must not be taken from the contributor [" +
-                    contributor + "] (except of gas fee)"
-                );
-                assertEq(
-                    prevFundWalletBalance,
-                    web3.eth.getBalance(fundWallet),
-                    "Amount must not be sent to the fund [" + fundWallet + "]"
-                );
-            });
-        }
-
+    async function ({ getAccount, fundOwner, getFund, withoutBalanceChangeIt }) {
         withoutBalanceChangeIt(
             "should not receive ETH from address not whitelisted",
             async (contributor) => {

--- a/test/gradualDeliveryCrowdsale.js
+++ b/test/gradualDeliveryCrowdsale.js
@@ -52,7 +52,7 @@ multipleContracts(
         async function addToWhitelist(...contributors) {
             if (contractName === "CarryTokenPresale") {
                 const fund = getFund();
-                await fund.addManyToWhitelist(
+                await fund.addAddressesToWhitelist(
                     contributors,
                     {from: fundOwner}
                 );

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,15 +1,16 @@
 /* eslint-disable no-console */
 
 function multipleContracts(contracts, callback) {
-    for (const [contractName, initArgs] of Object.entries(contracts)) {
+    for (const [testName, initArgs] of Object.entries(contracts)) {
         const CarryToken = artifacts.require("CarryToken");
+        const [contractName] = testName.trim().split(/\s+/);
         const Contract = artifacts.require(contractName);
 
         Contract.defaults({
             gasPrice: 40000000000,  // 40 gwei
         });
 
-        contract(contractName, async function (accounts) {
+        contract(testName, async function (accounts) {
             const reservedAccounts = 1;
             let accountIndex = reservedAccounts;
             const getAccount = () => {
@@ -83,7 +84,8 @@ function multipleContracts(contracts, callback) {
             }
 
             callback({
-                contractName: contractName,
+                testName,
+                contractName,
                 accounts,
                 getAccount,
                 fundWallet,

--- a/test/utils.js
+++ b/test/utils.js
@@ -99,13 +99,18 @@ function assertEvents(expectedEvents, result) {
 
 async function assertFail(promise, message) {
     let failed = false;
+    let tx;
     try {
-        await promise;
+        tx = await promise;
     } catch (e) {
-        console.log("An expected error has caught: " + e.toString());
         failed = true;
+        tx = null;
     }
-    assert.isTrue(failed, message);
+    const txid = tx && tx.tx;
+    if (!failed) {
+        console.error("assertFail() fails; txid: " + txid);
+    }
+    assert.isTrue(failed, message + "\ntxid: " + txid);
 }
 
 module.exports = {


### PR DESCRIPTION
This patch implements a smart contract for the Carry public sale which is distinct from the previous token presale.

First of all, although I had believed the most of things would be common between the presale and the public sale, it turns out not true.  The public sale needs to have timed individual caps, graded whitelists, and so on that the token presale didn't have.  On the other hand, the public sale doesn't have features like graded vesting or refunding, whereas the presale had them.

The assumptions I had when I write the `CarryTokenPresale` contract had driven me to prepare some generalizations over both token sales, hence `CarryTokenCrowdsale`.  As now it turns out that no many common things were left between both, `CarryTokenCrowdsale` cannot be used for the public sale.  So I renamed it to `CarryTokenPresaleBase`.

Instead, I started to write a distinct contract named `CarryPublicTokenCrowdsale` from scratch.  It now does:

- limit the minimum purchase per individual,
- limit the maximum purchase per individual,
- change the individual max cap by dates (it's zero at very first),
- disallow any purchases when it's paused or closed (due date),
- limit the max cap for the whole public sale, and
- prevent the gas war.

As the maximum individual purchases is zero at first, we don't have any distinct opening date, but only a closing date.

Also I generalized `multipleContracts()` function so that test codes share common things between both sales.

Plus, these trivial changes were also made:

- Upgraded tools and frameworks.
- Since the recent version of solium lint can recognize Solidity's `constructor()` keyword, all named constructors were replaced by `constructor()` keyword.
- `assertFail()` became to print txid when it fails for the sake of debugging.

@jckdotim @longfin @qria @segfault87 Please review this.