### PR TITLE
Graded whitelist

### DIFF
--- a/migrations/3_deploy_public_sale_contracts.js
+++ b/migrations/3_deploy_public_sale_contracts.js
@@ -32,6 +32,13 @@ const publicSale = {
     // Max cap: 5000.41 ETH = 373,781,000 CRE
     cap: web3.toWei(5000410, "finney"),
 
+    // Whitelist grades and available time for each grades
+    whitelistGrades: [
+        0,  // This must be zero; means a special state of "not whitelisted."
+        timestamp("2018-08-03T20:00:00+09:00"),  // KYC passed
+        timestamp("2018-08-01T20:00:00+09:00"),  // KYC & quiz passed
+    ],
+
     // Available time frame & individual caps
     individualMaxCaps: {
         [timestamp("2018-08-01T20:00:00+09:00")]: web3.toWei(5, "ether"),


### PR DESCRIPTION
This patch implements graded whitelist to the `CarryPublicTokenCrowdsale` contract.

Grades purpose to offer different available times to purchasers.  Each grade is indexed by an array index of `whitelistGrades` field.  The index number 0 is reserved to represent non-whitelisted addresses (and thus no grade).  Other index numbers are arbitrary; think of it as numbers of enumerated types in other programming languages.  The `whitelistGrades` maps a grade to a timestamp when addresses (i.e., people) that belong to the grade became able to purchase tokens.

The `addAddressesToWhitelist()` method takes multiple addresses and assign them to a grade.  If there are several grades and belonging addresses, this method needs to be called as many as the number of grades at least.  Addresses can be removed from the whitelist by calling `addAddressesToWhitelist(addresses, 0)` since the grade number zero means out of the whitelist.

Read the comments I wrote in the code as well.

@longfin @qria @segfault87 Please review this.