### PR TITLE
Refund

### DIFF
--- a/test/utils.js
+++ b/test/utils.js
@@ -92,7 +92,7 @@ function multipleContracts(contracts, callback) {
                 fundOwner,
                 getFund: () => fund,
                 getToken: () => token,
-                createFund: createFund,
+                createFund,
                 withoutBalanceChangeIt,
             });
         });


### PR DESCRIPTION
Similar to #4, except it only provides a *pull* model to receive deposited refunds (no *push* model).  The method name `receiveRefund()` is given to pull deposits; the `receiveRefundTo()` method (which was a name for *pull* model) was gone.

@longfin @qria @segfault87 Please review this.