### PR TITLE
Fixed token delivery due date & optimize gas efficiency

### DIFF
--- a/contracts/CarryPublicTokenCrowdsale.sol
+++ b/contracts/CarryPublicTokenCrowdsale.sol
@@ -107,14 +107,15 @@ contract CarryPublicTokenCrowdsale is CappedCrowdsale, Pausable {
         uint256 _individualMinPurchaseWei,
 
         // Since Solidity currently doesn't allows parameters to take array of
-        // structs, we work around this by taking (timestamp, weis) pairs as
-        // a 1d-array of [timestamp1, weis1, timestamp2, weis2, ...].
-        // It fails if the length is not even but odd.
-        uint256[] _individualMaxCaps
+        // structs, we work around this by taking two arrays for each field
+        // (timestmap and maxWei) separately.  It fails unless two arrays are
+        // of equal length.
+        uint256[] _individualMaxCapTimestamps,
+        uint256[] _individualMaxCapWeis
     ) public CappedCrowdsale(_cap) Crowdsale(_rate, _wallet, _token) {
         require(
-            _individualMaxCaps.length % 2 == 0,
-            "The length of _individualMaxCaps has to be even, not odd."
+            _individualMaxCapTimestamps.length == _individualMaxCapWeis.length,
+            "_individualMaxCap{Timestamps,Weis} do not have equal length."
         );
         if (_whitelistGrades.length < 1) {
             whitelistGrades = [0];
@@ -130,11 +131,12 @@ contract CarryPublicTokenCrowdsale is CappedCrowdsale, Pausable {
             whitelistGrades = _whitelistGrades;
         }
         individualMinPurchaseWei = _individualMinPurchaseWei;
-        for (uint256 i = 0; i < _individualMaxCaps.length; i += 2) {
+        for (uint i = 0; i < _individualMaxCapTimestamps.length; i++) {
+            uint256 timestamp = _individualMaxCapTimestamps[i];
             individualMaxCaps.push(
                 IndividualMaxCap(
-                    _individualMaxCaps[i],
-                    _individualMaxCaps[i + 1]
+                    timestamp,
+                    _individualMaxCapWeis[i]
                 )
             );
         }

--- a/contracts/CarryPublicTokenCrowdsale.sol
+++ b/contracts/CarryPublicTokenCrowdsale.sol
@@ -96,6 +96,11 @@ contract CarryPublicTokenCrowdsale is CappedCrowdsale, Pausable {
     // false at first, and then become true at some point.
     bool public withdrawable;
 
+    // The fixed due date (timestamp) of token delivery.  Even if withdrawable
+    // if not set to true, since the due date purchasers become able to withdraw
+    // tokens.  See also whenWithdrawable modifier below.
+    uint256 public tokenDeliveryDue;
+
     mapping(address => uint256) public refundedDeposits;
 
     constructor(
@@ -103,6 +108,7 @@ contract CarryPublicTokenCrowdsale is CappedCrowdsale, Pausable {
         CarryToken _token,
         uint256 _rate,
         uint256 _cap,
+        uint256 _tokenDeliveryDue,
         uint256[] _whitelistGrades,
         uint256 _individualMinPurchaseWei,
 
@@ -117,6 +123,7 @@ contract CarryPublicTokenCrowdsale is CappedCrowdsale, Pausable {
             _individualMaxCapTimestamps.length == _individualMaxCapWeis.length,
             "_individualMaxCap{Timestamps,Weis} do not have equal length."
         );
+        tokenDeliveryDue = _tokenDeliveryDue;
         if (_whitelistGrades.length < 1) {
             whitelistGrades = [0];
         } else {
@@ -133,6 +140,10 @@ contract CarryPublicTokenCrowdsale is CappedCrowdsale, Pausable {
         individualMinPurchaseWei = _individualMinPurchaseWei;
         for (uint i = 0; i < _individualMaxCapTimestamps.length; i++) {
             uint256 timestamp = _individualMaxCapTimestamps[i];
+            require(
+                i < 1 || timestamp > _individualMaxCapTimestamps[i - 1],
+                "_individualMaxCapTimestamps have to be in ascending order and no duplications."
+            );
             individualMaxCaps.push(
                 IndividualMaxCap(
                     timestamp,
@@ -176,14 +187,23 @@ contract CarryPublicTokenCrowdsale is CappedCrowdsale, Pausable {
         );
 
         // See also the comment on the individualMaxCaps above.
-        uint256 latestTimestamp = 0;
         uint256 individualMaxWei = 0;
-        for (uint256 i = 0; i < individualMaxCaps.length; i++) {
+        for (uint i = 0; i < individualMaxCaps.length; i++) {
+            uint256 capTimestamp = individualMaxCaps[i].timestamp;
             // solium-disable-next-line security/no-block-members
-            if (individualMaxCaps[i].timestamp <= block.timestamp &&
-                individualMaxCaps[i].timestamp > latestTimestamp) {
-                latestTimestamp = individualMaxCaps[i].timestamp;
+            if (capTimestamp <= block.timestamp) {
                 individualMaxWei = individualMaxCaps[i].maxWei;
+            } else {
+                // Optimize gas consumption by trimming timestamps no more used.
+                if (i > 1) {
+                    uint offset = i - 1;
+                    uint trimmedLength = individualMaxCaps.length - offset;
+                    for (uint256 j = 0; j < trimmedLength; j++) {
+                        individualMaxCaps[j] = individualMaxCaps[offset + j];
+                    }
+                    individualMaxCaps.length = trimmedLength;
+                }
+                break;
             }
         }
         require(
@@ -226,8 +246,16 @@ contract CarryPublicTokenCrowdsale is CappedCrowdsale, Pausable {
         withdrawable = _withdrawable;
     }
 
-    function withdrawTokens() public {
-        require(withdrawable, "Currently tokens cannot be withdrawn.");
+    modifier whenWithdrawable() {
+        require(
+            // solium-disable-next-line security/no-block-members
+            withdrawable || block.timestamp >= tokenDeliveryDue,
+            "Currently tokens cannot be withdrawn."
+        );
+        _;
+    }
+
+    function withdrawTokens() public whenWithdrawable {
         uint256 amount = balances[msg.sender];
         require(amount > 0, "No balance to withdraw.");
         balances[msg.sender] = 0;

--- a/contracts/CarryToken.sol
+++ b/contracts/CarryToken.sol
@@ -26,7 +26,7 @@ contract CarryToken is PausableToken, CappedToken, BurnableToken {
 
     // See also <https://carryprotocol.io/#section-token-distribution>.
     //                10 billion <---------|   |-----------------> 10^18
-    uint256 constant TOTAL_CAP = 10000000000 * 1000000000000000000;
+    uint256 constant TOTAL_CAP = 10000000000 * (10 ** uint256(decimals));
 
     constructor() public CappedToken(TOTAL_CAP) {
     }

--- a/migrations/3_deploy_public_sale_contracts.js
+++ b/migrations/3_deploy_public_sale_contracts.js
@@ -83,6 +83,7 @@ module.exports = (deployer, network, accounts) => {
         return CarryToken.deployed();
     }).then((_carryToken) => {
         carryToken = _carryToken;
+        const caps = Object.entries(publicSale.individualMaxCaps);
         return deployer.deploy(
             CarryPublicTokenCrowdsale,
             publicSale.wallet,
@@ -91,9 +92,8 @@ module.exports = (deployer, network, accounts) => {
             publicSale.cap,
             publicSale.closingTime,
             publicSale.individualMinPurchaseWei,
-            Object.entries(publicSale.individualMaxCaps).reduce(
-                (a, b) => a.concat(b)
-            )
+            caps.map(pair => pair[0]),
+            caps.map(pair => pair[1]),
         );
     }).then(c => {
         return new Promise(resolve => setTimeout(() => resolve(c), delay));

--- a/migrations/3_deploy_public_sale_contracts.js
+++ b/migrations/3_deploy_public_sale_contracts.js
@@ -32,6 +32,9 @@ const publicSale = {
     // Max cap: 5000.41 ETH = 373,781,000 CRE
     cap: web3.toWei(5000410, "finney"),
 
+    // Due date of token delivery
+    tokenDeliveryDue: timestamp("2019-01-01T00:00:00+09:00"),
+
     // Whitelist grades and available time for each grades
     whitelistGrades: [
         // This must be zero; means a special state of "not whitelisted."

--- a/migrations/3_deploy_public_sale_contracts.js
+++ b/migrations/3_deploy_public_sale_contracts.js
@@ -34,16 +34,24 @@ const publicSale = {
 
     // Whitelist grades and available time for each grades
     whitelistGrades: [
-        0,  // This must be zero; means a special state of "not whitelisted."
-        timestamp("2018-08-03T20:00:00+09:00"),  // KYC passed
-        timestamp("2018-08-01T20:00:00+09:00"),  // KYC & quiz passed
+        // This must be zero; means a special state of "not whitelisted."
+        0,
+
+        // Everyone who passed KYC/AML
+        timestamp("2018-08-26T20:00:00+00:00"),
+
+        // KYC/AML, quiz passed & non-target region
+        timestamp("2018-08-27T20:00:00+09:00"),
+
+        // KYC/AML, quiz passed & target region
+        timestamp("2018-08-28T20:00:00+09:00"),
     ],
 
     // Available time frame & individual caps
     individualMaxCaps: {
-        [timestamp("2018-08-01T20:00:00+09:00")]: web3.toWei(5, "ether"),
-        [timestamp("2018-08-03T20:00:00+09:00")]: web3.toWei(10, "ether"),
-        [timestamp("2018-08-15T20:00:00+09:00")]: 0,  // closing time
+        [timestamp("2018-08-26T20:00:00+09:00")]: web3.toWei(5, "ether"),
+        [timestamp("2018-08-28T20:00:00+09:00")]: web3.toWei(10, "ether"),
+        [timestamp("2018-09-09T20:00:00+09:00")]: 0,  // closing time
     },
     // Due to gas fee, contributors tend to transfer incorrect amount of
     // ETH which doesn't satisfy the minimum purchase by a whisker,

--- a/test/carryPublicTokenCrowdsale.js
+++ b/test/carryPublicTokenCrowdsale.js
@@ -20,10 +20,11 @@ const {
     multipleContracts,
 } = require("./utils");
 
-const currentTimestamp = +new Date() / 1000 >> 0;
+const now = +new Date() / 1000 >> 0;
 const minute = 60;
 const hour = 60 * minute;
 const day = 24 * hour;
+const week = 7 * day;
 
 multipleContracts({
     "CarryPublicTokenCrowdsale (not opened yet)": (fundWallet, token) => [
@@ -34,16 +35,12 @@ multipleContracts({
         token.address,  // token contract
         65000,  // rate
         web3.toWei(5000410, "finney"),  // cap
-        [0, currentTimestamp + 14 * day],  // whitelistGrades
+        [0, now + 2 * week],  // whitelistGrades
         web3.toWei(99, "finney"),  // individualMinPurchaseWei
-        [  // individualMaxCaps
-            currentTimestamp + 14 * day,  // 2 weeks later
-            web3.toWei(5, "ether"),
-            currentTimestamp + 21 * day,  // 3 weeks later
-            web3.toWei(10, "ether"),
-            currentTimestamp + 31 * day,  // closingTime: a month later
-            0,
-        ],
+        // individual mas caps
+        // 2 weeks later         3 weeks later            closing: a month later
+        [now + 2 * week,         now + 3 * week,          now + 31 * day],
+        [web3.toWei(5, "ether"), web3.toWei(10, "ether"), 0],
     ],
     "CarryPublicTokenCrowdsale (opened; phase 1)": (fundWallet, token) => [
         // Use similar arguments to the publicSale (though not necessarily).
@@ -55,18 +52,14 @@ multipleContracts({
         web3.toWei(5000410, "finney"),  // cap
         [  // whitelistGrades
             0,
-            currentTimestamp - 7 * day,
-            currentTimestamp + 7 * day,
+            now - week,
+            now + week,
         ],
         web3.toWei(99, "finney"),  // individualMinPurchaseWei
-        [  // individualMaxCaps
-            currentTimestamp - 7 * day,  // a week ago
-            web3.toWei(5, "ether"),
-            currentTimestamp + 7 * day,  // a week later
-            web3.toWei(10, "ether"),
-            currentTimestamp + 14 * day,  // closingTime: 2 weeks later
-            0,
-        ],
+        // individual mas caps
+        // a week ago            a week later             closing: 2 weeks later
+        [now - week,             now + week,              now + 2 * week],
+        [web3.toWei(5, "ether"), web3.toWei(10, "ether"), 0],
     ],
     "CarryPublicTokenCrowdsale (opened; phase 2)": (fundWallet, token) => [
         // Use similar arguments to the publicSale (though not necessarily).
@@ -78,18 +71,14 @@ multipleContracts({
         web3.toWei(5000410, "finney"),  // cap
         [  // whitelistGrades
             0,
-            currentTimestamp - 14 * day,
-            currentTimestamp - 7 * day,
+            now - 2 * week,
+            now - week,
         ],
         web3.toWei(99, "finney"),  // individualMinPurchaseWei
-        [  // individualMaxCaps
-            currentTimestamp - 14 * day,  // 2 weeks ago
-            web3.toWei(5, "ether"),
-            currentTimestamp - 7 * day,  // a week ago
-            web3.toWei(10, "ether"),
-            currentTimestamp + 14 * day,  // closingTime: 2 weeks later
-            0,
-        ],
+        // individual mas caps
+        // 2 weeks ago           a week ago               closing: 2 weeks later
+        [now - 2 * week,         now - week,              now + 2 * week],
+        [web3.toWei(5, "ether"), web3.toWei(10, "ether"), 0],
     ],
     "CarryPublicTokenCrowdsale (already closed)": (fundWallet, token) => [
         // Use similar arguments to the publicSale (though not necessarily).
@@ -99,16 +88,12 @@ multipleContracts({
         token.address,  // token contract
         65000,  // rate
         web3.toWei(5000410, "finney"),  // cap
-        [0, currentTimestamp - 31 * day],  // whitelistGrades
+        [0, now - 31 * day],  // whitelistGrades
         web3.toWei(99, "finney"),  // individualMinPurchaseWei
-        [
-            currentTimestamp - 31 * day,  // a month ago
-            web3.toWei(5, "ether"),
-            currentTimestamp - 14 * day,  // 2 weeks ago
-            web3.toWei(10, "ether"),
-            currentTimestamp - 7 * day,  // closingTime: a week ago
-            0,
-        ],
+        // individual mas caps
+        // a month ago           2 weeks ago              closing: a week ago
+        [now - 31 * day,         now - 2 * week,          now - week],
+        [web3.toWei(5, "ether"), web3.toWei(10, "ether"), 0],
     ],
 }, ({
     testName,


### PR DESCRIPTION
This patch has several improvements.  The main changes are adding the fixed due date of token delivery, and optimization to decrease gas consumption.

- As token purchasers maybe concerned that we never call `setWithdrawal(true)`, to dispel these worries, `_tokenDeliveryDue` field was added.  `whenWithdrawable` modifier will allow purchasers to withdraw their tokens after the due date even if we don't call `setWithdrawal(true)` ever.
- Since the past timestamps are no more used, make the `_individualMaxCaps` table automatically trimmed.

@longfin @qria @segfault87 Please review this.